### PR TITLE
Redispatching edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ anything with the help of mybinder:
 # Make the tests
 Some tests (unit test, non regression test etc.) are provided with this package. They are located at grid2op/tests.
 
+Additional packages are required to run the tests:
+```
+pip install -e .[test]
+```
+
 The tests can be performed with the command:
 ```commandline
 cd grid2op/tests

--- a/grid2op/BasicEnv.py
+++ b/grid2op/BasicEnv.py
@@ -745,7 +745,7 @@ class _BasicEnv(GridObjects, ABC):
         infos = {"disc_lines": disc_lines,
                  "is_illegal": is_illegal,
                  "is_ambiguous": is_ambiguous,
-                 "is_dipatching_illegal": is_illegal_redisp,
+                 "is_dispatching_illegal": is_illegal_redisp,
                  "is_illegal_reco": is_illegal_reco,
                  "exception": except_}
         self.done = self._is_done(has_error, is_done)

--- a/grid2op/tests/test_RedispatchEnv.py
+++ b/grid2op/tests/test_RedispatchEnv.py
@@ -13,7 +13,7 @@ from Exceptions import *
 from Environment import Environment
 from BackendPandaPower import PandaPowerBackend
 from Parameters import Parameters
-from ChronicsHandler import ChronicsHandler, GridStateFromFile
+from ChronicsHandler import ChronicsHandler, GridStateFromFile, ChangeNothing
 from Reward import L2RPNReward
 from MakeEnv import make
 from GameRules import GameRules, DefaultRules
@@ -74,7 +74,7 @@ class TestRedispatch(unittest.TestCase):
         self.array_double_dispatch = np.array([0.,  10.,  20.,   0., -30.])
 
     def tearDown(self):
-        pass
+        self.env.close()
 
     def compare_vect(self, pred, true):
         return np.max(np.abs(pred- true)) <= self.tolvect
@@ -247,20 +247,84 @@ class TestRedispatch(unittest.TestCase):
         assert np.all(obs.prod_p[:-1] <= self.env.gen_pmax[:-1])
         assert np.all(obs.prod_p[:-1] >= self.env.gen_pmin[:-1])
 
-
-    def test_redispacth_generator_off(self):
-        """ Redispatching a turned off generator should terminate """
+    def test_redispacth_non_dispatchable_generator(self):
+        """ Cannot dispatch a non dispatchable generator """
         act = self.env.action_space()
         obs, reward, done, info = self.env.step(act)
 
-        assert np.all(self.env.gen_uptime == np.array([0, 1, 1, 0, 1]))
-        assert np.all(self.env.gen_downtime == np.array([1, 0, 0, 1, 0]))
-        assert np.all(obs.prod_p <= self.env.gen_pmax)
-        assert np.all(obs.prod_p >= self.env.gen_pmin)
+        # Generator 0 is non-dispatchable
+        # Check that generator 0 is off
+        assert self.env.gen_downtime[0] >= 1
 
+        # Try to redispatch
         redispatch_act = self.env.action_space({"redispatch": [(0, 5.)]})
         obs, reward, done, info = self.env.step(redispatch_act)
         assert done == True
+
+
+class TestRedispatchChangeNothingEnvironment(unittest.TestCase):
+    def setUp(self):
+        # powergrid
+        self.backend = PandaPowerBackend()
+        self.path_matpower = PATH_DATA_TEST_PP
+        self.case_file = "test_case14.json"
+        # chronics
+        self.path_chron = os.path.join(PATH_CHRONICS, "chronics")
+        self.chronics_handler = ChronicsHandler(chronicsClass=ChangeNothing)
+        self.tolvect = 1e-2
+        self.tol_one = 1e-5
+        self.id_chron_to_back_load = np.array([0, 1, 10, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # force the verbose backend
+        self.backend.detailed_infos_for_cascading_failures = True
+        self.names_chronics_to_backend = {"loads": {"2_C-10.61": 'load_1_0', "3_C151.15": 'load_2_1',
+                                                    "14_C63.6": 'load_13_2', "4_C-9.47": 'load_3_3',
+                                                    "5_C201.84": 'load_4_4',
+                                                    "6_C-6.27": 'load_5_5', "9_C130.49": 'load_8_6',
+                                                    "10_C228.66": 'load_9_7',
+                                                    "11_C-138.89": 'load_10_8', "12_C-27.88": 'load_11_9',
+                                                    "13_C-13.33": 'load_12_10'},
+                                          "lines": {'1_2_1': '0_1_0', '1_5_2': '0_4_1', '9_10_16': '8_9_2',
+                                                    '9_14_17': '8_13_3',
+                                                    '10_11_18': '9_10_4', '12_13_19': '11_12_5', '13_14_20': '12_13_6',
+                                                    '2_3_3': '1_2_7', '2_4_4': '1_3_8', '2_5_5': '1_4_9',
+                                                    '3_4_6': '2_3_10',
+                                                    '4_5_7': '3_4_11', '6_11_11': '5_10_12', '6_12_12': '5_11_13',
+                                                    '6_13_13': '5_12_14', '4_7_8': '3_6_15', '4_9_9': '3_8_16',
+                                                    '5_6_10': '4_5_17',
+                                                    '7_8_14': '6_7_18', '7_9_15': '6_8_19'},
+                                          "prods": {"1_G137.1": 'gen_0_4', "3_G36.31": "gen_2_1", "6_G63.29": "gen_5_2",
+                                                    "2_G-56.47": "gen_1_0", "8_G40.43": "gen_7_3"},
+                                          }
+
+        # _parameters for the environment
+        self.env_params = Parameters()
+        self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
+                               backend=self.backend,
+                               chronics_handler=self.chronics_handler,
+                               parameters=self.env_params,
+                               names_chronics_to_backend=self.names_chronics_to_backend,
+                               actionClass=Action)
+
+    def tearDown(self):
+        self.env.close()
+
+    def test_redispatch_generator_off(self):
+        """ Redispatch a turned off generator should terminate """
+
+        # Step into simulation once
+        nothing_act = self.env.action_space()
+        obs, reward, done, info = self.env.step(nothing_act)
+        # Check that generator 1 is off
+        assert obs.prod_p[1] == 0
+        assert self.env.gen_downtime[1] >= 1
+        
+        # Try to redispatch generator 1
+        redispatch_act = self.env.action_space({"redispatch": [(1, 5.)]})
+        obs, reward, done, info = self.env.step(redispatch_act)
+        
+        assert done == True
+        
 
 class TestLoadingBackendPandaPower(unittest.TestCase):
     def setUp(self):

--- a/grid2op/tests/test_RedispatchEnv.py
+++ b/grid2op/tests/test_RedispatchEnv.py
@@ -328,7 +328,7 @@ class TestRedispatchChangeNothingEnvironment(unittest.TestCase):
         redispatch_act = self.env.action_space({"redispatch": [(1, 5.)]})
         obs, reward, done, info = self.env.step(redispatch_act)
         
-        assert info['is_dipatching_illegal'] == True
+        assert info['is_dispatching_illegal'] == True
 
 class TestLoadingBackendPandaPower(unittest.TestCase):
     def setUp(self):

--- a/grid2op/tests/test_RedispatchEnv.py
+++ b/grid2op/tests/test_RedispatchEnv.py
@@ -248,7 +248,20 @@ class TestRedispatch(unittest.TestCase):
         assert np.all(obs.prod_p[:-1] >= self.env.gen_pmin[:-1])
 
 
-# # TODO test that if i try to redispatched a turned off generator it breaks everything
+    def test_redispacth_generator_off(self):
+        """ Redispatching a turned off generator should terminate """
+        act = self.env.action_space()
+        obs, reward, done, info = self.env.step(act)
+
+        assert np.all(self.env.gen_uptime == np.array([0, 1, 1, 0, 1]))
+        assert np.all(self.env.gen_downtime == np.array([1, 0, 0, 1, 0]))
+        assert np.all(obs.prod_p <= self.env.gen_pmax)
+        assert np.all(obs.prod_p >= self.env.gen_pmin)
+
+        redispatch_act = self.env.action_space({"redispatch": [(0, 5.)]})
+        obs, reward, done, info = self.env.step(redispatch_act)
+        assert done == True
+
 class TestLoadingBackendPandaPower(unittest.TestCase):
     def setUp(self):
         # powergrid


### PR DESCRIPTION
Provides new tests for invalid re-dispatch actions, fix small typos and missing install commands. 

Note that the simulation isn't expected to end at these edge cases. Instead, the info dictionary is providing feedback:
- Re-dispatching a non-dispatchable generator is ambiguous
- Re-dispatching a turned off generator is illegal