### PR TITLE
More tests, some fixes

### DIFF
--- a/grid2op/ChronicsHandler.py
+++ b/grid2op/ChronicsHandler.py
@@ -1720,7 +1720,7 @@ class Multifolder(GridValue):
             self.subpaths.sort()
             self.subpaths = np.array(self.subpaths)
         except FileNotFoundError:
-            raise ChronicsNotFoundError("Path \"{self.path}\" doesn't exists.")
+            raise ChronicsNotFoundError("Path \"{}\" doesn't exists.".format(self.path))
 
 
         if len(self.subpaths) == 0:

--- a/grid2op/ChronicsHandler.py
+++ b/grid2op/ChronicsHandler.py
@@ -1720,7 +1720,7 @@ class Multifolder(GridValue):
             self.subpaths.sort()
             self.subpaths = np.array(self.subpaths)
         except FileNotFoundError:
-            raise ChronicsNotFoundError("Path \"{}\" doesn't exists.".format(self.path))
+            raise ChronicsError("Path \"{}\" doesn't exists.".format(self.path))
 
 
         if len(self.subpaths) == 0:

--- a/grid2op/ChronicsHandler.py
+++ b/grid2op/ChronicsHandler.py
@@ -1732,7 +1732,7 @@ class Multifolder(GridValue):
             self.subpaths.sort()
             self.subpaths = np.array(self.subpaths)
         except FileNotFoundError:
-            raise ChronicsError("Path \"{}\" doesn't exists.".format(self.path))
+            raise ChronicsError("Path \"{}\" doesn't exists.".format(self.path)) from None
 
 
         if len(self.subpaths) == 0:

--- a/grid2op/ChronicsHandler.py
+++ b/grid2op/ChronicsHandler.py
@@ -1714,10 +1714,14 @@ class Multifolder(GridValue):
         self.data = None
         self.path = os.path.abspath(path)
         self.sep = sep
-        self.subpaths = [os.path.join(self.path, el) for el in os.listdir(self.path)
-                         if os.path.isdir(os.path.join(self.path, el))]
-        self.subpaths.sort()
-        self.subpaths = np.array(self.subpaths)
+        try:
+            self.subpaths = [os.path.join(self.path, el) for el in os.listdir(self.path)
+                             if os.path.isdir(os.path.join(self.path, el))]
+            self.subpaths.sort()
+            self.subpaths = np.array(self.subpaths)
+        except FileNotFoundError:
+            raise ChronicsNotFoundError("Path \"{self.path}\" doesn't exists.")
+
 
         if len(self.subpaths) == 0:
             raise ChronicsNotFoundError("Not chronics are found in \"{}\". Make sure there are at least "

--- a/grid2op/MakeEnv.py
+++ b/grid2op/MakeEnv.py
@@ -176,8 +176,7 @@ def _get_default_aux(name, kwargs, defaultClassApp, _sentinel=None,
                 try:
                     res = defaultClass(**build_kwargs)
                 except Exception as e:
-                    err_msg = "Cannot create and instance of {} with parameters \"{}\""
-                    print(err_msg.format(name, defaultClass, build_kwargs))
+                    e.args = e.args + ("Cannot create and instance of {} with parameters \"{}\"".format(defaultClass, build_kwargs),)
                     raise
             elif defaultinstance is not None:
                 if len(build_kwargs):

--- a/grid2op/Observation.py
+++ b/grid2op/Observation.py
@@ -104,8 +104,8 @@ class ObsEnv(_BasicEnv):
                           legalActClass=legalActClass)
         self.no_overflow_disconnection = parameters.NO_OVERFLOW_DISCONNECTION
 
-        self._load_p, self._load_q, _ =  None, None, None
-        self._prod_p, _, self._prod_v = None, None, None
+        self._load_p, self._load_q, self._load_v =  None, None, None
+        self._prod_p, self._prod_q, self._prod_v = None, None, None
         self._topo_vect = None
 
         # convert line status to -1 / 1 instead of false / true
@@ -149,6 +149,7 @@ class ObsEnv(_BasicEnv):
         self.game_rules = GameRules(legalActClass=legalActClass)
         self.legalActClass = legalActClass
         self.helper_action_player = lambda x: self.donothing_act
+        self.backend.set_thermal_limit(self._thermal_limit_a)
 
     def _update_actions(self):
         """
@@ -260,6 +261,7 @@ class ObsEnv(_BasicEnv):
                 - "is_ambiguous" (``bool``) whether the action given as input was ambiguous.
 
         """
+        self.backend.set_thermal_limit(self._thermal_limit_a)
         self.backend.apply_action(self._action)
         return self.step(action)
         # return self.current_obs, reward, has_error, {}
@@ -290,23 +292,22 @@ class ObsEnv(_BasicEnv):
         res = self.current_obs
         return res
 
-    def update_grid(self, real_backend):
+    def update_grid(self, env):
         """
         Update this "emulated" environment with the real powergrid.
 
         Parameters
         ----------
-        real_backend: :class:`grid2op.Backend.Backend`
-            The real grid of the environment.
+        env: :class:`grid2op.Environement._BasicEnv`
+            A reference to the environement
 
         Returns
         -------
 
         """
-        # self.backend = real_backend.copy()
-
-        self._load_p, self._load_q, _ = real_backend.loads_info()
-        self._prod_p, _, self._prod_v = real_backend.generators_info()
+        real_backend = env.backend
+        self._load_p, self._load_q, self._load_v = real_backend.loads_info()
+        self._prod_p, self._prod_q, self._prod_v = real_backend.generators_info()
         self._topo_vect = real_backend.get_topo_vect()
 
         # convert line status to -1 / 1 instead of false / true
@@ -315,7 +316,16 @@ class ObsEnv(_BasicEnv):
         self._line_status -= 1  # false -> -1; true -> 1
         self.is_init = False
 
-        # TODO get the state of redispatching and other vectors as well
+        # Make a copy of env state for simulation
+        self._thermal_limit_a = env._thermal_limit_a
+        self.gen_activeprod_t[:] = env.gen_activeprod_t[:]
+        self.times_before_line_status_actionable[:] = env.times_before_line_status_actionable[:]
+        self.times_before_topology_actionable[:]  = env.times_before_topology_actionable[:]
+        self.time_remaining_before_line_reconnection[:] = env.time_remaining_before_line_reconnection[:]
+        self.time_next_maintenance[:] = env.time_next_maintenance[:]
+        self.duration_next_maintenance[:] = env.duration_next_maintenance[:]
+        self.target_dispatch[:] = env.target_dispatch[:]
+        self.actual_dispatch[:] = env.actual_dispatch[:]
         # TODO check redispatching and simulate are working as intended
         # TODO also update the status of hazards, maintenance etc.
         # TODO and simulate also when a maintenance is forcasted!
@@ -992,13 +1002,13 @@ class Observation(GridObjects):
         if time_step >= len(self._forecasted_inj):
             raise NoForecastAvailable("Forecast for {} timestep ahead is not possible with your chronics.".format(time_step))
 
-        if self._forecasted_grid[time_step] is None:
-            # initialize the "simulation environment" with the proper injections
-            self._forecasted_grid[time_step] = self._obs_env.copy()
-            timestamp, inj_forecasted = self._forecasted_inj[time_step]
-            inj_action = self.action_helper(inj_forecasted)
-            self._forecasted_grid[time_step].init(inj_action, time_stamp=timestamp,
-                                                  timestep_overflow=self.timestep_overflow)
+        timestamp, inj_forecasted = self._forecasted_inj[time_step]
+        inj_action = self.action_helper(inj_forecasted)
+        # initialize the "simulation environment" with the proper injections
+        self._forecasted_grid[time_step] = self._obs_env.copy()
+        self._forecasted_grid[time_step].init(inj_action, time_stamp=timestamp,
+                                              timestep_overflow=self.timestep_overflow)
+
         return self._forecasted_grid[time_step].simulate(action)
 
     def copy(self):
@@ -1460,7 +1470,7 @@ class ObservationHelper(SerializableObservationSpace):
                               parameters=env.parameters,
                               reward_helper=self.reward_helper,
                               action_helper=self.action_helper_env,
-                              thermal_limit_a=self.backend_obs.thermal_limit_a,
+                              thermal_limit_a=env._thermal_limit_a,
                               legalActClass=env.legalActClass,
                               donothing_act=env.helper_action_player())
 
@@ -1470,7 +1480,7 @@ class ObservationHelper(SerializableObservationSpace):
         self._update_env_time = 0.
 
     def __call__(self, env):
-        self.obs_env.update_grid(env.backend)
+        self.obs_env.update_grid(env)
 
         res = self.observationClass(gridobj=self,
                                     obs_env=self.obs_env,

--- a/grid2op/Runner.py
+++ b/grid2op/Runner.py
@@ -617,7 +617,7 @@ class Runner(object):
               (episode) but not at lower levels (setp during the episode)
         """
         pbar_ = _FakePbar()
-        next_pbar[0] = None
+        next_pbar[0] = False
 
         if isinstance(pbar, bool):
             if pbar:

--- a/grid2op/tests/test_ChronicsHandler.py
+++ b/grid2op/tests/test_ChronicsHandler.py
@@ -570,7 +570,7 @@ class TestMissingData(HelperTests):
     def test_load_error(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            with self.assertRaises(ChronicsNotFoundError):
+            with self.assertRaises(ChronicsError):
                 with make("case14_realistic", chronics_path="/answer/life/42"):
                     pass
 

--- a/grid2op/tests/test_ChronicsHandler.py
+++ b/grid2op/tests/test_ChronicsHandler.py
@@ -570,8 +570,8 @@ class TestMissingData(HelperTests):
     def test_load_error(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            with self.assertRaises(ChronicsError):
-                with make("case14_realistic", chronics_path="/home/benjamin/Documents/grid2op_dev/grid2op/tests"):
+            with self.assertRaises(ChronicsNotFoundError):
+                with make("case14_realistic", chronics_path="/answer/life/42"):
                     pass
 
     def run_env_till_over(self, env, max_iter):

--- a/grid2op/tests/test_Observation.py
+++ b/grid2op/tests/test_Observation.py
@@ -727,7 +727,7 @@ class TestSimulateEqualsStep(unittest.TestCase):
         self.env.chronics_handler.real_data.data.prod_v_forecast = np.roll(self.env.chronics_handler.real_data.data.prod_v, -1, axis=0)
         self.env.chronics_handler.real_data.data.load_p_forecast = np.roll(self.env.chronics_handler.real_data.data.load_p, -1, axis=0)
         self.env.chronics_handler.real_data.data.load_q_forecast = np.roll(self.env.chronics_handler.real_data.data.load_q, -1, axis=0)
-        self.obs, _, _, _ = self.env.step(self.env.action_space())
+        self.obs, _, _, _ = self.env.step(self.env.action_space({}))
 
         self.sim_obs = None
         self.step_obs = None
@@ -929,7 +929,7 @@ class TestSimulateEqualsStep(unittest.TestCase):
         # Get set status vector
         set_status = self.env.action_space.get_set_line_status_vect()
         # Make a change
-        set_status[1] = -1 if self.obs.line_status[0] else 1
+        set_status[1] = -1 if self.obs.line_status[1] else 1
         # Register set action
         set_act = self.env.action_space({'set_line_status': set_status})
         actions.append(set_act)

--- a/grid2op/tests/test_Observation.py
+++ b/grid2op/tests/test_Observation.py
@@ -1024,5 +1024,8 @@ class TestSimulateEqualsStep(unittest.TestCase):
         # Test observations are the same
         assert self.sim_obs == self.step_obs
 
+## TODO test -- Add test to cover simulation vs step when there is a planned maintenance operation
+
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
 - Adds environment state copy for ObsEnv. This ensures that simulate behavior is coherent with step. Appropriate tests are now passing. Also makes sure thermals limits for simulation are correct.
Note that caching of ObsEnv for a given timestep is still present, but running another simulate at the same timestep will ovveride the previous cached ObsEnv 
 
 - Chronics loading invalid path is fixed and tested. 

 - Runner test_sequential fix, multiple calls to make_progress_bar where causing python internal error using `with` decorator and None return type. False is returned instead, fixing the error and keeping the same behavior. 