### PR TITLE
BridgeReward & "line_change" subset for AgentWithConverter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,10 @@ Change Log
 
 [0.6.1] - 2020-xx-yy
 --------------------
-TODO for next versions
+- [ADDED] BridgeReward. A reward based on graph connectivity, see implementation in grid2op.Reward.BridgeReward for details
 
+[TODO]
+--------------------
 - [???] test and doc for opponent
 - [???] better logging
 - [???] rationalize the public and private part of the API. Some members now are public but should be private.
@@ -47,7 +49,6 @@ TODO for next versions
 - [DEPRECATION] `LegalAction` class has renamed `BaseRules` that serve as an abstract base class for all
   type of rules classes. Name `LegalAction` will be deprecated in future versions.
 - [DEPRECATION] typo fixed in `PreventReconection` class (now properly named `PreventReconnection`)
-- [ADDED] BridgeReward. A reward based on graph connectivity, see implementation for details
 - [ADDED] different kind of "Opponent" can now be implemented if needed (missing deep testing, different type of
   class, and good documentation)
 - [ADDED] implement other "rewards" to look at. It is now possible to have an environment that will compute more rewards

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ TODO for next versions
 - [DEPRECATION] `LegalAction` class has renamed `BaseRules` that serve as an abstract base class for all
   type of rules classes. Name `LegalAction` will be deprecated in future versions.
 - [DEPRECATION] typo fixed in `PreventReconection` class (now properly named `PreventReconnection`)
+- [ADDED] BridgeReward. A reward based on graph connectivity, see implementation for details
 - [ADDED] different kind of "Opponent" can now be implemented if needed (missing deep testing, different type of
   class, and good documentation)
 - [ADDED] implement other "rewards" to look at. It is now possible to have an environment that will compute more rewards

--- a/baselines/DoubleDuelingDQN/cmd.sh
+++ b/baselines/DoubleDuelingDQN/cmd.sh
@@ -1,2 +1,3 @@
 ./train.py  --num_pre_steps 256 --num_train_steps 131072 --path_data ../../grid2op/data/rte_case14_realistic/ --name dqn-XX.0.0.0 --num_frames 4
 ./eval.py --path_data ../../grid2op/data/rte_L2RPN_2019/chronics/ --path_model ./dqn-XX.0.0.0 --path_logs ./logs_eval --nb_episode 5
+./inspect_action_space.py --path_data ../../grid2op/data/rte_case14_realistic/

--- a/baselines/DoubleDuelingDQN/inspect_action_space.py
+++ b/baselines/DoubleDuelingDQN/inspect_action_space.py
@@ -71,7 +71,7 @@ def print_actions(agent):
             "line_disconnect": prune_impact_count(impact["force_line"]["disconnections"], "count"),
             "connect_bus": prune_impact_array(impact["topology"], "assigned_bus"),
             "disconnect_bus": prune_impact_array(impact["topology"], "disconnect_bus"),
-            "switch_line": prune_impact_bool(impact["switch_line"], "changed"),
+            "switch_line": prune_impact_array(impact["switch_line"], "powerlines"),
             "switch_bus": prune_impact_array(impact["topology"], "bus_switch"),
             "redispatch": prune_impact_array(impact["redispatch"], "generators")
         }

--- a/grid2op/Action/SerializableActionSpace.py
+++ b/grid2op/Action/SerializableActionSpace.py
@@ -340,6 +340,34 @@ class SerializableActionSpace(SerializableSpace):
         return self._template_act.get_change_line_status_vect()
 
     @staticmethod
+    def get_all_unitary_line_set(action_space):
+        res = []
+
+        # powerline switch: disconnection
+        for i in range(action_space.n_line):
+            res.append(action_space.disconnect_powerline(line_id=i))
+
+        # powerline switch: reconnection
+        for bus_or in [1, 2]:
+            for bus_ex in [1, 2]:
+                for i in range(action_space.n_line):
+                    act = action_space.reconnect_powerline(line_id=i, bus_ex=bus_ex, bus_or=bus_or)
+                    res.append(act)
+
+        return res
+
+    @staticmethod
+    def get_all_unitary_line_change(action_space):
+        res = []
+
+        for i in range(action_space.n_line):
+            status = action_space.get_change_line_status_vect()
+            status[i] = True
+            res.append(action_space({"change_line_status": status}))
+
+        return res
+
+    @staticmethod
     def get_all_unitary_topologies_change(action_space):
         """
         This methods allows to compute and return all the unitary topological changes that can be performed on a

--- a/grid2op/Converter/IdToAct.py
+++ b/grid2op/Converter/IdToAct.py
@@ -79,23 +79,15 @@ class IdToAct(Converter):
             self.all_actions.append(super().__call__())
 
             if "_set_line_status" in self._template_act.attr_list_vect:
-                # powerline switch: disconnection
-                for i in range(self.n_line):
-                    self.all_actions.append(self.disconnect_powerline(line_id=i))
+                # lines 'set'
+                self.all_actions += self.get_all_unitary_line_set(self)
 
-                # powerline switch: reconnection
-                for bus_or in [1, 2]:
-                    for bus_ex in [1, 2]:
-                        for i in range(self.n_line):
-                            tmp_act = self.reconnect_powerline(line_id=i, bus_ex=bus_ex, bus_or=bus_or)
-                            self.all_actions.append(tmp_act)
-            elif "_switch_line_status" in self._template_act.attr_list_vect:
-                warnings.warn("\"_set_line_status\" is not possible, but \"_switch_line_status\" is. However this"
-                              "behaviour is not supported at the moment.")
-                # TODO support that above ^
+            if "_switch_line_status" in self._template_act.attr_list_vect:
+                # lines 'change'
+                self.all_actions += self.get_all_unitary_line_change(self)
 
             if "_set_topo_vect" in self._template_act.attr_list_vect:
-                # topologies using the 'set' method
+                # topologies 'set'
                 self.all_actions += self.get_all_unitary_topologies_set(self)
 
             if "_change_bus_vect" in self._template_act.attr_list_vect:

--- a/grid2op/Reward/BridgeReward.py
+++ b/grid2op/Reward/BridgeReward.py
@@ -1,0 +1,53 @@
+import networkx as nx
+
+from grid2op.Reward.BaseReward import BaseReward
+
+class BridgeReward(BaseReward):
+    def __init__(self):
+        BaseReward.__init__(self)
+        self.reward_min = 0
+        self.reward_max = 1000.0
+
+    def __call__(self, action, env, has_error, is_done, is_illegal, is_ambiguous):
+        n_bus = 3
+        
+        # Get info from env
+        obs = env.current_obs
+        n_sub = obs.n_sub
+        n_line = obs.n_line
+        topo = obs.topo_vect
+        or_topo = obs.line_or_pos_topo_vect
+        ex_topo = obs.line_ex_pos_topo_vect
+        or_sub = obs.line_or_to_subid
+        ex_sub = obs.line_ex_to_subid
+        
+        # Create a graph of vertices
+        # Use one vertex per substation per bus
+        G = nx.Graph()
+        G.add_nodes_from(range(n_sub * n_bus))
+        
+        # Set lines edges for current bus
+        for line_idx in range(n_line):
+            # Skip if line is disconnected
+            if obs.line_status[line_idx] is False:
+                continue
+            
+            # Get the buses for current line
+            lor_bus = topo[or_topo[line_idx]]
+            lex_bus = topo[ex_topo[line_idx]]
+
+            if lor_bus == 0 or lex_bus == 0:
+                continue
+
+            # Compute edge vertices indices for current graph
+            left_v = (lor_bus - 1) * n_sub
+            right_v = (lex_bus - 1) * n_sub
+
+            # Register edge in graph
+            G.add_edge(left_v, right_v)
+            
+        # Find the bridges
+        n_bridges = len(list(nx.bridges(G)))
+
+        reward = self.reward_max - (250.0 * n_bridges)
+        return reward

--- a/grid2op/Reward/__init__.py
+++ b/grid2op/Reward/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "IncreasingFlatReward",
     "L2RPNReward",
     "RedispReward",
+    "BridgeReward",
     "RewardHelper",
     "BaseReward"
 ]
@@ -15,6 +16,7 @@ from grid2op.Reward.FlatReward import FlatReward
 from grid2op.Reward.IncreasingFlatReward import IncreasingFlatReward
 from grid2op.Reward.L2RPNReward import L2RPNReward
 from grid2op.Reward.RedispReward import RedispReward
+from grid2op.Reward.BridgeReward import BridgeReward
 from grid2op.Reward.RewardHelper import RewardHelper
 from grid2op.Reward.BaseReward import BaseReward
 import warnings

--- a/grid2op/tests/test_Reward.py
+++ b/grid2op/tests/test_Reward.py
@@ -7,7 +7,7 @@ import warnings
 import numbers
 from abc import ABC, abstractmethod
 from grid2op.tests.helper_path_test import *
-from grid2op.Reward import BaseReward, ConstantReward, EconomicReward, FlatReward, L2RPNReward, RedispReward
+from grid2op.Reward import *
 from grid2op import make
 
 
@@ -55,6 +55,10 @@ class TestLoadingL2RPNReward(TestLoadingReward, unittest.TestCase):
 class TestLoadingRedispReward(TestLoadingReward, unittest.TestCase):
     def _create_reward(self):
         return RedispReward()
+
+class TestLoadingBridgeReward(TestLoadingReward, unittest.TestCase):
+    def _create_reward(self):
+        return BridgeReward()
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ pkgs = {
         "pandas>=1.0.3",
         "pandapower>=2.2.2",
         "tqdm>=4.43.0",
-        "pathlib>=1.0.1"
+        "pathlib>=1.0.1",
+        "networkx>=2.4"
     ],
     "extras": {
         "test": [
@@ -35,7 +36,8 @@ pkgs = {
             "pandas==1.0.3",
             "pandapower==2.2.2",
             "tqdm==4.43.0",
-            "pathlib==1.0.1"
+            "pathlib==1.0.1",
+            "networkx==2.4"
         ],
         "docs": [
             "numpydoc>=0.9.2",


### PR DESCRIPTION
- Adds the `BridgeReward` that yields a penality based on how many bridges are present in grid network at the given time t. This could be used to incentivize an agent to respect the N + 1 rule.
- Harmonizes `IdToAct` & `SerializableActionSpace `to be able to use both subsets of line actions ('set' or 'change') together or separately. Much like it has been done for topology ('set' and 'change') actions.