### PR TITLE
removing duplicate attribute for environment about line reconnection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,16 +23,21 @@ Change Log
 
   [0.8.0] - 2020-05-xx
 ----------------------
+- [BREAKING] All previously deprecated features have been removed
+- [BREAKING] `grid2op.Runner` is now located into a submodule folder
+- [BREAKING]  merge of `env.time_before_line_reconnectable` into `env.times_before_line_status_actionable` which
+  referred to
+  the same idea: impossibility to reconnect a powerilne. **Side effect** observation have a different size now (
+  merging of `obs.time_before_line_reconnectable` into `obs.time_before_cooldown_line`). Size is now reduce of
+  the number of powerlines of the grid.
+- [FIXED] `grid2op.PlotGrid` rounding error when casting from np.float32 to python.float
+- [FIXED] `grid2op.BaseEnv.fast_forward_chronics` Calls the correct methods and is now working properly
 - [UPDATED] Notebooks are updated to reflect API improvements changes
 - [UPDATED] `grid2op.make` can now handle the download & caching of datasets
 - [UPDATED] Test/Sample datasets provide datetime related files .info
 - [UPDATED] Test/Sample datasets grid_layout.json
 - [UPDATED] `grid2op.PlotGrid` Color schemes and optional infos displaying
 - [UPDATED] `grid2op.Episode.EpisodeReplay` Improved gif output performance
-- [BREAKING] All previously deprecated features have been removed 
-- [BREAKING] `grid2op.Runner` is now located into a submodule folder
-- [FIXED] `grid2op.PlotGrid` rounding error when casting from np.float32 to python.float
-- [FIXED] `grid2op.BaseEnv.fast_forward_chronics` Calls the correct methods and is now working properly
 
 [0.7.1] - 2020-04-22
 ----------------------
@@ -43,10 +48,13 @@ Change Log
   floating value are always `np.float32` and integers are always `np.int32`
 - [ADDED] a method to extract only some part of a chronic.
 - [ADDED] a method to "fast forward" the chronics
-- [ADDED] class `grid2op.Reward.CombinedScaledReward`: A reward combiner with linear interpolation to stay within a given range.
-- [ADDED] `grid2op.Reward.BaseReward.set_range`: All rewards have a default setter for their `reward_min` and `reward_max` attributes.
+- [ADDED] class `grid2op.Reward.CombinedScaledReward`: A reward combiner with linear interpolation to stay within a
+  given range.
+- [ADDED] `grid2op.Reward.BaseReward.set_range`: All rewards have a default setter for their `reward_min` and
+  `reward_max` attributes.
 - [ADDED] `grid2op.PlotGrid`: Revamped plotting capabilities while keeping the interface we know from `grid2op.Plot`
-- [ADDED] `grid2op.replay` binary: This binary is installed with grid2op and allows to replay a runner log with visualization and gif export
+- [ADDED] `grid2op.replay` binary: This binary is installed with grid2op and allows to replay a runner log with
+  visualization and gif export
 - [ADDED] a `LicensesInformation` file that put a link for all dependencies of the project.
 - [ADDED] make multiple dockers, one for testing, one for distribution with all extra, and one "light"
 - [UPDATED] test data and datasets are no longer included in the package distribution
@@ -76,11 +84,13 @@ Change Log
   operations only
 - [ADDED] `grid2op.Action.PowerlineSetAndDispatchAction` A subset of actions to limit the agents scope to 'set line'
   and 'dispatch' operations only
-- [ADDED] `grid2op.Action.PowerlineSetAction` A subset of actions to limit the agents scope to 'set line' operations only
+- [ADDED] `grid2op.Action.PowerlineSetAction` A subset of actions to limit the agents scope to 'set line' operations
+  only
 - [ADDED] `grid2op.Action.TopologySetAction` A subset of actions to limit the agents scope to 'set' operations only
 - [ADDED] `grid2op.Action.TopologySetAndDispatchAction` A subset of actions to limit the agents scope to 'set' and
   'redisp' operations only
-- [ADDED] `grid2op.Action.TopologyChangeAction` A subset of actions to limit the agents scope to 'change' operations only
+- [ADDED] `grid2op.Action.TopologyChangeAction` A subset of actions to limit the agents scope to 'change' operations
+  only
 - [ADDED] `grid2op.Action.TopologyChangeAndDispatchAction` A subset of actions to limit the agents scope to 'change'
   and 'redisp' operations only
 - [ADDED] `grid2op.Action.DispatchAction` A subset of actions to limit the agents scope to 'redisp' operations only
@@ -116,7 +126,8 @@ Change Log
 - [ADDED] CombinedReward. A reward combiner to compute a weighted sum of other rewards.
 - [ADDED] CloseToOverflowReward. A reward that penalize agents when lines have almost reached max capacity.
 - [ADDED] DistanceReward. A reward based on how far way from the original topology the current grid is.
-- [ADDED] BridgeReward. A reward based on graph connectivity, see implementation in grid2op.Reward.BridgeReward for details
+- [ADDED] BridgeReward. A reward based on graph connectivity, see implementation in grid2op.Reward.BridgeReward for
+  details
 
 [0.6.0] - 2020-04-03
 ---------------------

--- a/grid2op/Action/BaseAction.py
+++ b/grid2op/Action/BaseAction.py
@@ -213,34 +213,36 @@ class BaseAction(GridObjects):
                                 "set_bus", "change_bus", "redispatch"}
 
         # False(line is disconnected) / True(line is connected)
-        self._set_line_status = None
-        self._switch_line_status = None
+        self._set_line_status = np.full(shape=self.n_line, fill_value=0, dtype=dt_int)
+        self._switch_line_status = np.full(shape=self.n_line, fill_value=False, dtype=dt_bool)
 
         # injection change
         self._dict_inj = {}
 
-        # redispatching
-        self._redispatch = None
-
         # topology changed
-        self._set_topo_vect = None
-        self._change_bus_vect = None
-
-        self._vectorized = None
-
-        self._subs_impacted = None
-        self._lines_impacted = None
+        self._set_topo_vect = np.full(shape=self.dim_topo, fill_value=0, dtype=dt_int)
+        self._change_bus_vect = np.full(shape=self.dim_topo, fill_value=False, dtype=dt_bool)
 
         # add the hazards and maintenance usefull for saving.
-        self._hazards = None
-        self._maintenance = None
+        self._hazards = np.full(shape=self.n_line, fill_value=False, dtype=dt_bool)
+        self._maintenance = np.full(shape=self.n_line, fill_value=False, dtype=dt_bool)
 
-        # shunt data (not available in all backends)
-        self.shunt_p = None
-        self.shunt_q = None
-        self.shunt_bus = None
+        # redispatching vector
+        self._redispatch = np.full(shape=self.n_gen, fill_value=0., dtype=dt_float)
 
-        self.reset()
+        self._vectorized = None
+        self._lines_impacted = None
+        self._subs_impacted = None
+
+        # shunts
+        if self.shunts_data_available:
+            self.shunt_p = np.full(shape=self.n_shunt, fill_value=np.NaN, dtype=dt_float)
+            self.shunt_q = np.full(shape=self.n_shunt, fill_value=np.NaN, dtype=dt_float)
+            self.shunt_bus = np.full(shape=self.n_shunt, fill_value=0, dtype=dt_int)
+        else:
+            self.shunt_p = None
+            self.shunt_q = None
+            self.shunt_bus = None
 
         # decomposition of the BaseAction into homogeneous sub-spaces
         self.attr_list_vect = ["prod_p", "prod_v", "load_p", "load_q", "_redispatch",
@@ -553,22 +555,22 @@ class BaseAction(GridObjects):
 
         """
         # False(line is disconnected) / True(line is connected)
-        self._set_line_status = np.full(shape=self.n_line, fill_value=0, dtype=dt_int)
-        self._switch_line_status = np.full(shape=self.n_line, fill_value=False, dtype=dt_bool)
+        self._set_line_status[:] = 0
+        self._switch_line_status[:] = False
 
         # injection change
         self._dict_inj = {}
 
         # topology changed
-        self._set_topo_vect = np.full(shape=self.dim_topo, fill_value=0, dtype=dt_int)
-        self._change_bus_vect = np.full(shape=self.dim_topo, fill_value=False, dtype=dt_bool)
+        self._set_topo_vect[:] = 0
+        self._change_bus_vect[:] = False
 
         # add the hazards and maintenance usefull for saving.
-        self._hazards = np.full(shape=self.n_line, fill_value=False, dtype=dt_bool)
-        self._maintenance = np.full(shape=self.n_line, fill_value=False, dtype=dt_bool)
+        self._hazards[:] = False
+        self._maintenance[:] = False
 
         # redispatching vector
-        self._redispatch = np.full(shape=self.n_gen, fill_value=0., dtype=dt_float)
+        self._redispatch[:] = 0.
 
         self._vectorized = None
         self._lines_impacted = None
@@ -576,9 +578,9 @@ class BaseAction(GridObjects):
 
         # shunts
         if self.shunts_data_available:
-            self.shunt_p = np.full(shape=self.n_shunt, fill_value=np.NaN, dtype=dt_float)
-            self.shunt_q = np.full(shape=self.n_shunt, fill_value=np.NaN, dtype=dt_float)
-            self.shunt_bus = np.full(shape=self.n_shunt, fill_value=0, dtype=dt_int)
+            self.shunt_p[:] = np.NaN
+            self.shunt_q[:] = np.NaN
+            self.shunt_bus[:] = 0
 
     def __iadd__(self, other):
         """

--- a/grid2op/Observation/CompleteObservation.py
+++ b/grid2op/Observation/CompleteObservation.py
@@ -70,16 +70,13 @@ class CompleteObservation(BaseObservation):
             [:attr:`grid2op.Space.GridObjects.n_line` elements]
         26. :attr:`BaseObservation.time_before_cooldown_sub` representation of the cooldown time on the substations
             [:attr:`grid2op.Space.GridObjects.n_sub` elements]
-        27. :attr:`BaseObservation.time_before_line_reconnectable` number of timestep to wait before a powerline
-            can be reconnected (it is disconnected due to maintenance, cascading failure or overflow)
-            [:attr:`grid2op.Space.GridObjects.n_line` elements]
-        28. :attr:`BaseObservation.time_next_maintenance` number of timestep before the next maintenance (-1 means
+        27. :attr:`BaseObservation.time_next_maintenance` number of timestep before the next maintenance (-1 means
             no maintenance are planned, 0 a maintenance is in operation) [:attr:`BaseObservation.n_line` elements]
-        29. :attr:`BaseObservation.duration_next_maintenance` duration of the next maintenance. If a maintenance
+        28. :attr:`BaseObservation.duration_next_maintenance` duration of the next maintenance. If a maintenance
             is taking place, this is the number of timestep before it ends. [:attr:`BaseObservation.n_line` elements]
-        30. :attr:`BaseObservation.target_dispatch` the target dispatch for each generator
+        29. :attr:`BaseObservation.target_dispatch` the target dispatch for each generator
             [:attr:`grid2op.Space.GridObjects.n_gen` elements]
-        31. :attr:`BaseObservation.actual_dispatch` the actual dispatch for each generator
+        30. :attr:`BaseObservation.actual_dispatch` the actual dispatch for each generator
             [:attr:`grid2op.Space.GridObjects.n_gen` elements]
 
     This behavior is specified in the :attr:`BaseObservation.attr_list_vect` vector.
@@ -112,7 +109,6 @@ class CompleteObservation(BaseObservation):
             "line_status", "timestep_overflow",
             "topo_vect",
             "time_before_cooldown_line", "time_before_cooldown_sub",
-            "time_before_line_reconnectable",
             "time_next_maintenance", "duration_next_maintenance",
             "target_dispatch", "actual_dispatch"
         ]
@@ -168,7 +164,6 @@ class CompleteObservation(BaseObservation):
         # cool down and reconnection time after hard overflow, soft overflow or cascading failure
         self.time_before_cooldown_line[:] = env.times_before_line_status_actionable
         self.time_before_cooldown_sub[:] = env.times_before_topology_actionable
-        self.time_before_line_reconnectable[:] = env.time_remaining_before_line_reconnection
         self.time_next_maintenance[:] = env.time_next_maintenance
         self.duration_next_maintenance[:] = env.duration_next_maintenance
 
@@ -234,7 +229,6 @@ class CompleteObservation(BaseObservation):
             self.dictionnarized["cooldown"] = {}
             self.dictionnarized["cooldown"]['line'] = self.time_before_cooldown_line
             self.dictionnarized["cooldown"]['substation'] = self.time_before_cooldown_sub
-            self.dictionnarized["time_before_line_reconnectable"] = self.time_before_line_reconnectable
             self.dictionnarized["redispatching"] = {}
             self.dictionnarized["redispatching"]["target_redispatch"] = self.target_dispatch
             self.dictionnarized["redispatching"]["actual_dispatch"] = self.actual_dispatch

--- a/grid2op/Observation/_ObsEnv.py
+++ b/grid2op/Observation/_ObsEnv.py
@@ -266,17 +266,17 @@ class _ObsEnv(BaseEnv):
 
         # Make a copy of env state for simulation
         self._thermal_limit_a = env._thermal_limit_a.astype(dt_float)
-        self.gen_activeprod_t[:] = env.gen_activeprod_t[:].astype(dt_float)
-        self.gen_activeprod_t_redisp[:] = env.gen_activeprod_t_redisp[:].astype(dt_float)
-        self.times_before_line_status_actionable[:] = env.times_before_line_status_actionable[:].astype(dt_int)
-        self.times_before_topology_actionable[:]  = env.times_before_topology_actionable[:].astype(dt_int)
-        self.time_remaining_before_line_reconnection[:] = env.time_remaining_before_line_reconnection[:].astype(dt_int)
-        self.time_next_maintenance[:] = env.time_next_maintenance[:].astype(dt_int)
-        self.duration_next_maintenance[:] = env.duration_next_maintenance[:].astype(dt_int)
-        self.target_dispatch[:] = env.target_dispatch[:].astype(dt_float)
-        self.actual_dispatch[:] = env.actual_dispatch[:].astype(dt_float)
-        self.last_bus_line_or = env.last_bus_line_or[:].astype(dt_int)
-        self.last_bus_line_ex = env.last_bus_line_ex[:].astype(dt_int)
+        self.gen_activeprod_t[:] = env.gen_activeprod_t
+        self.gen_activeprod_t_redisp[:] = env.gen_activeprod_t_redisp
+        self.times_before_line_status_actionable[:] = env.times_before_line_status_actionable
+        self.times_before_topology_actionable[:] = env.times_before_topology_actionable
+        # self.time_remaining_before_line_reconnection[:] = env.time_remaining_before_line_reconnection
+        self.time_next_maintenance[:] = env.time_next_maintenance
+        self.duration_next_maintenance[:] = env.duration_next_maintenance
+        self.target_dispatch[:] = env.target_dispatch
+        self.actual_dispatch[:] = env.actual_dispatch
+        self.last_bus_line_or[:] = env.last_bus_line_or
+        self.last_bus_line_ex[:] = env.last_bus_line_ex
         # TODO check redispatching and simulate are working as intended
         # TODO also update the status of hazards, maintenance etc.
         # TODO and simulate also when a maintenance is forcasted!

--- a/grid2op/Reward/LinesReconnectedReward.py
+++ b/grid2op/Reward/LinesReconnectedReward.py
@@ -33,12 +33,7 @@ class LinesReconnectedReward(BaseReward):
         # All lines ids
         lines_id = np.array(list(range(env.n_line)))
         # Only off cooldown lines
-        lines_off_cooldown = lines_id[
-            np.logical_and(
-                (obs.time_before_cooldown_line <= 0), # Can be acted on
-                (obs.time_before_line_reconnectable <= 0) # Can be reconnected
-            )
-        ]
+        lines_off_cooldown = lines_id[obs.time_before_cooldown_line <= 0 ]
 
         n_penalties = 0.0
         for line_id in lines_off_cooldown:

--- a/grid2op/Rules/PreventReconnection.py
+++ b/grid2op/Rules/PreventReconnection.py
@@ -28,12 +28,9 @@ class PreventReconnection(BaseRules):
 
         """
         aff_lines, aff_subs = action.get_topological_impact()
-        if np.any(env.time_remaining_before_line_reconnection[aff_lines] > 0):
-            # i tried to act on a powerline removed because an overflow
-            return False
-
         if np.any(env.times_before_line_status_actionable[aff_lines] > 0):
             # i tried to act on a powerline too shortly after a previous action
+            # or shut down due to an overflow or opponent or hazards or maintenance
             return False
 
         if np.any(env.times_before_topology_actionable[aff_subs] > 0):

--- a/grid2op/tests/test_Observation.py
+++ b/grid2op/tests/test_Observation.py
@@ -139,16 +139,16 @@ class TestLoadingBackendFunc(unittest.TestCase):
                                 dt_float, dt_float, dt_float,
                                 dt_float, dt_float, dt_float,
                                 dt_float, dt_bool, dt_int, dt_int,
-                                dt_int, dt_int, dt_int,
+                                dt_int, dt_int,
                                 dt_int, dt_int, dt_float, dt_float],
                                dtype=object)
 
         self.dtypes = np.array([np.dtype(el) for el in self.dtypes])
 
         self.shapes = np.array([ 1,  1,  1,  1,  1,  1,  5,  5,  5, 11, 11, 11, 20, 20, 20, 20, 20,
-                                            20, 20, 20, 20, 20, 20, 56, 20, 14, 20, 20, 20,
+                                            20, 20, 20, 20, 20, 20, 56, 20, 14, 20, 20,
                                  5, 5])
-        self.size_obs = 434
+        self.size_obs = 414
 
     def test_sum_shape_equal_size(self):
         obs = self.env.helper_observation(self.env)
@@ -520,14 +520,14 @@ class TestObservationHazard(unittest.TestCase):
     def test_1_generating_obs_withhazard(self):
         # test that helper_obs is abl to generate a valid observation
         obs = self.env.get_obs()
-        assert np.all(obs.time_before_line_reconnectable == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert np.all(obs.time_before_cooldown_line == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         action = self.env.helper_action_player({})
         _ = self.env.step(action)
         obs = self.env.get_obs()
-        assert np.all(obs.time_before_line_reconnectable == [0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert np.all(obs.time_before_cooldown_line == [0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         _ = self.env.step(action)
         obs = self.env.get_obs()
-        assert np.all(obs.time_before_line_reconnectable == [0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert np.all(obs.time_before_cooldown_line == [0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
 
 class TestObservationMaintenance(unittest.TestCase):
@@ -709,7 +709,7 @@ class TestUpdateEnvironement(unittest.TestCase):
         # Check left cooldowns are updated to the rhs CDs
         assert np.all(self.lobs.time_before_cooldown_line == self.robs.time_before_cooldown_line)
         assert np.all(self.lobs.time_before_cooldown_sub == self.robs.time_before_cooldown_sub)
-        assert np.all(self.lobs.time_before_line_reconnectable == self.robs.time_before_line_reconnectable)
+        assert np.all(self.lobs.time_before_cooldown_line == self.robs.time_before_cooldown_line)
         assert np.all(self.lobs.time_next_maintenance == self.robs.time_next_maintenance)
         assert np.all(self.lobs.duration_next_maintenance == self.robs.duration_next_maintenance)
 

--- a/grid2op/tests/test_PandaPowerBackend.py
+++ b/grid2op/tests/test_PandaPowerBackend.py
@@ -1130,7 +1130,6 @@ class TestResetEqualsLoadGrid(unittest.TestCase):
         assert np.all(obs1.timestep_overflow == obs2.timestep_overflow)
         assert np.all(obs1.time_before_cooldown_line == obs2.time_before_cooldown_line)
         assert np.all(obs1.time_before_cooldown_sub == obs2.time_before_cooldown_sub)
-        assert np.all(obs1.time_before_line_reconnectable == obs2.time_before_line_reconnectable)
         assert np.all(obs1.time_next_maintenance == obs2.time_next_maintenance)
         assert np.all(obs1.duration_next_maintenance == obs2.duration_next_maintenance)
         assert np.all(obs1.target_dispatch == obs2.target_dispatch)

--- a/grid2op/tests/test_RedispatchEnv.py
+++ b/grid2op/tests/test_RedispatchEnv.py
@@ -535,6 +535,7 @@ class TestLoadingBackendPandaPower(HelperTests):
             assert np.all(obs.prod_p[0:2] >= -obs.gen_pmin[0:2])
             assert np.abs(np.sum(obs.actual_dispatch)) <= self.tol_one
             assert len(info['exception']) == 0, "error at iteration {}".format(i)
+
             i += 1
             obs_init = obs
             if i >= max_iter:

--- a/grid2op/tests/test_Rules.py
+++ b/grid2op/tests/test_Rules.py
@@ -118,9 +118,6 @@ class TestLoadingBackendFunc(unittest.TestCase):
         arr_line2[id_line2] = 2
 
         self.helper_action.legal_action = RulesChecker(legalActClass=LookParam).legal_action
-        self.env.times_before_line_status_actionable[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         self.env.parameters.MAX_SUB_CHANGED = 2
         self.env.parameters.MAX_LINE_STATUS_CHANGED = 2
@@ -179,40 +176,34 @@ class TestLoadingBackendFunc(unittest.TestCase):
         arr_line2[id_line2] = 2
 
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=dt_int)
-
         self.env.parameters.MAX_SUB_CHANGED = 1
         self.env.parameters.MAX_LINE_STATUS_CHANGED = 2
-        _ = self.helper_action({"change_bus": {"substations_id": [(id_1, arr1)]},
+        act = self.helper_action({"change_bus": {"substations_id": [(id_1, arr1)]},
                                 "set_bus": {"substations_id": [(id_2, arr2)]},
                                 "change_line_status": arr_line1,
                                 "set_line_status": arr_line2},
                                env=self.env,
                                check_legal=True)
-
+        _ = self.env.step(act)
 
         try:
             self.env.parameters.MAX_SUB_CHANGED = 2
             self.env.parameters.MAX_LINE_STATUS_CHANGED = 1
-            self.env.time_remaining_before_line_reconnection[id_line] = 1
+            self.env.times_before_line_status_actionable[id_line] = 1
             _ = self.helper_action({"change_bus": {"substations": [(id_1, arr1)]},
-                                                             "set_bus": {"substations_id": [(id_2, arr2)]},
-                                                             "change_line_status": arr_line1,
-                                                             "set_line_status": arr_line2},
-                                                            env=self.env,
-                                                            check_legal=True)
+                                    "set_bus": {"substations_id": [(id_2, arr2)]},
+                                    "change_line_status": arr_line1,
+                                    "set_line_status": arr_line2},
+                                   env=self.env,
+                                   check_legal=True)
             raise RuntimeError("This should have thrown an IllegalException")
         except IllegalAction:
             pass
 
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
+        self.env.times_before_line_status_actionable[:] = 0
         self.env.parameters.MAX_SUB_CHANGED = 2
         self.env.parameters.MAX_LINE_STATUS_CHANGED = 1
-        self.env.time_remaining_before_line_reconnection[1] = 1
+        self.env.times_before_line_status_actionable[1] = 1
         _ = self.helper_action({"change_bus": {"substations": [(id_1, arr1)]},
                                                          "set_bus": {"substations_id": [(id_2, arr2)]},
                                                          "change_line_status": arr_line1,
@@ -236,9 +227,6 @@ class TestLoadingBackendFunc(unittest.TestCase):
 
         self.env.max_timestep_line_status_deactivated = 1
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         # i act a first time on powerline 15
         act = self.helper_action({"set_line_status": arr_line2},
@@ -270,9 +258,6 @@ class TestLoadingBackendFunc(unittest.TestCase):
 
         self.env.max_timestep_line_status_deactivated = 1
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         # i act a first time on powerline 15
         act = self.helper_action({"set_line_status": arr_line2},
@@ -302,18 +287,17 @@ class TestLoadingBackendFunc(unittest.TestCase):
         arr_line2[id_line2] = -1
 
         self.env.max_timestep_line_status_deactivated = 2
+        self.env.parameters.NB_TIMESTEP_LINE_STATUS_REMODIF = 2
+
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         # i act a first time on powerline 15
         act = self.helper_action({"set_line_status": arr_line2},
-                               env=self.env,
-                               check_legal=True)
-        self.env.step(act)
+                                 env=self.env,
+                                 check_legal=True)
+        _ = self.env.step(act)
         # i compute another time step without doing anything
-        self.env.step(self.helper_action({}))
+        _ = self.env.step(self.helper_action({}))
 
         # i try to react on it, it should throw an IllegalAction exception because we ask the environment to wait
         # at least 2 time steps
@@ -342,9 +326,6 @@ class TestLoadingBackendFunc(unittest.TestCase):
 
         self.env.max_timestep_topology_deactivated = 1
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         # i act a first time on powerline 15
         act = self.helper_action({"set_bus": {"substations_id": [(id_2, arr2)]}},
@@ -376,9 +357,6 @@ class TestLoadingBackendFunc(unittest.TestCase):
 
         self.env.max_timestep_topology_deactivated = 1
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         # i act a first time on powerline 15
         act = self.helper_action({"set_bus": {"substations_id": [(id_2, arr2)]}},
@@ -409,9 +387,6 @@ class TestLoadingBackendFunc(unittest.TestCase):
 
         self.env.max_timestep_topology_deactivated = 2
         self.helper_action.legal_action = RulesChecker(legalActClass=PreventReconnection).legal_action
-        self.env.time_remaining_before_line_reconnection[:] = np.full(shape=(self.env.backend.n_line,),
-                                                              fill_value=0,
-                                                              dtype=np.int)
 
         # i act a first time on powerline 15
         act = self.helper_action({"set_bus": {"substations_id": [(id_2, arr2)]}},


### PR DESCRIPTION
- [BREAKING]  merge of `env.time_before_line_reconnectable` into `env.times_before_line_status_actionable` which referred to the same idea: impossibility to reconnect a powerilne. **Side effect** observation have a different size now ( merging of `obs.time_before_line_reconnectable` into `obs.time_before_cooldown_line`). Size is now reduce of the number of powerlines of the grid.

Also: i tried to clean up creation / modification of numpy array. They are created once, and then their values are updated with the `array[:] = new_values`, thus: reducing creation of temp numpy array and improve "type safety" (even if it's python...)