### PR TITLE
0.9.0 EpisodeRelay gif steps bounds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Change Log
   with changing the bus of the generator representing the slack bus.
 - [FIXED] Greedy agents now uses the proper data types `dt_float` for the simulated reward (previously it was platform
   dependant)
+- [ADDED] A way to limit `EpisodeReplay` to a specific part of the episode. Two arguments have been added, namely: `start_step` and `end_step` that default to the full episode duration.
 - [ADDED] more flexibilities in `IdToAct` converter not to generate every action for both set and change for example.
   This class can also serialize and de serialize the list of all actions with the save method (to serialize) and the
   `init_converter` method (to read back the data).

--- a/grid2op/Episode/EpisodeReplay.py
+++ b/grid2op/Episode/EpisodeReplay.py
@@ -56,7 +56,8 @@ class EpisodeReplay(object):
         self.agent_path = agent_path
         self.episode_data = None
 
-    def replay_episode(self, episode_id, fps=2.0, gif_name=None, display=True):
+    def replay_episode(self, episode_id, fps=2.0, gif_name=None,
+                       display=True, start_step=0, end_step=-1):
         """
         When called, this function will start the display of the episode in a "mini movie" format.
 
@@ -72,6 +73,13 @@ class EpisodeReplay(object):
         gif_name: ``str``
             If provided, a .gif file is saved in the episode folder with the name :gif_name:. 
             The .gif extension is appened by this function
+
+        start_step: ``int``
+            Default to 0. The step at which to start generating the gif
+
+        end_step: ``int``
+            Default to -1. The step at which to stop generating the gif.
+            Set to -1 to specify no limit
         """
         # Check args
         path_ep = os.path.join(self.agent_path, episode_id)
@@ -94,7 +102,13 @@ class EpisodeReplay(object):
         # Render loop
         figure = None
         time_per_frame = 1.0 / fps
-        for obs in all_obs:
+        for step, obs in enumerate(all_obs):
+            # Skip up to start_step
+            if step < start_step:
+                continue
+            # Terminate if reached end_step
+            if end_step > 0 and step >= end_step:
+                break
             # Get a timestamp for current frame
             start_time = time.time()
 


### PR DESCRIPTION
Adds paramters to bound the gif generation to a number of steps. (Defaults to the full episode duration)

This is **REQUIRED** for codalab gif output: https://github.com/marota/Grid2Op_EnvironmentDesign/pull/5 