### PR TITLE
Obs.simulate reward

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Change Log
 - [BREAKING] `MultiEnv` has been renamed `SingleEnvMultiProcess`
 - [BREAKING] `MultiEnv` has been abstracted to `BaseMultiProcessEnv` and the backwards compatible interface is now
   `SingleProcessMultiEnv`
+- [FIXED] `obs.simulate` post-initialized reward behaves like the environment
 - [FIXED] `LinesReconnectedReward` fixes reward inverted range
 - [FIXED] the `get_all_unitary_topologies_change` now counts only once the "do nothing" action.
 - [FIXED] `obs.simulate` could sometime returns "None" when the simulated action lead to a game over. This is no longer

--- a/grid2op/Observation/_ObsEnv.py
+++ b/grid2op/Observation/_ObsEnv.py
@@ -299,6 +299,8 @@ class _ObsEnv(BaseEnv):
 
         """
         real_backend = env.backend
+        self.reward_helper = env.reward_helper
+
         self._load_p, self._load_q, self._load_v = real_backend.loads_info()
         self._prod_p, self._prod_q, self._prod_v = real_backend.generators_info()
         self._topo_vect = real_backend.get_topo_vect()

--- a/grid2op/tests/test_Reward.py
+++ b/grid2op/tests/test_Reward.py
@@ -163,7 +163,22 @@ class TestCombinedReward(TestLoadingReward, unittest.TestCase):
 
         set_action = self.env.action_space({"set_bus": {"lines_or_id": [(1,2)]}})
         obs, r, d, info = self.env.step(set_action)
-        assert r < 1.0 
-        
+        assert r < 1.0
+
+    def test_combine_simulate(self):
+        cr = self.env.reward_helper.template_reward
+        assert cr is not None
+        gr = GameplayReward()
+        gr.set_range(-21.0, 21.0)
+        added = cr.addReward("Gameplay", gr, 2.0)
+        assert added is True
+
+        obs = self.env.reset()
+        cr.initialize(self.env)
+        _, r, d, i = obs.simulate(self.env.action_space({}))
+        assert d is False
+        assert r == 42.0
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix a bug where for post-initialized rewards: `simulate` and `step` would not return the same reward value.