### PR TITLE
MultiMixEnvironment access by env name

### DIFF
--- a/grid2op/Environment/MultiMixEnv.py
+++ b/grid2op/Environment/MultiMixEnv.py
@@ -95,6 +95,17 @@ class MultiMixEnvironment(GridObjects, RandomObject):
     def __getattr__(self, name):
         return getattr(self.current_env, name)
 
+    def keys(self):
+        for mix in self.mix_envs:
+            yield mix.name
+
+    def values(self):
+        for mix in self.mix_envs:
+            yield mix
+
+    def items(self):
+        for mix in self.mix_envs:
+            yield mix.name, mix
 
     def __getitem__(self, key):
         """

--- a/grid2op/Environment/MultiMixEnv.py
+++ b/grid2op/Environment/MultiMixEnv.py
@@ -95,6 +95,31 @@ class MultiMixEnvironment(GridObjects, RandomObject):
     def __getattr__(self, name):
         return getattr(self.current_env, name)
 
+
+    def __getitem__(self, key):
+        """
+        Operator [] overload for accesing underlying mixes by name
+
+        .. code-block:: python
+
+            import grid2op
+            from grid2op.Environment import MultiMixEnvironment
+
+            mm_env = MultiMixEnvironment("/path/to/multi/dataset/folder")
+
+            mix1_env.name = mm_env["mix_1"]
+            assert mix1_env == "mix_1"
+            mix2_env.name = mm_env["mix_2"]
+            assert mix2_env == "mix_2"
+        """
+        # Search for key
+        for mix in self.mix_envs:
+            if mix.name == key:
+                return mix
+
+        # Not found by name
+        raise KeyError
+    
     def reset(self, random=False):
         if random:
             self.env_index = self.space_prng.randint(len(self.mix_envs))

--- a/grid2op/tests/test_MultiMix.py
+++ b/grid2op/tests/test_MultiMix.py
@@ -228,5 +228,16 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert isinstance(info, dict)
         assert done is not True
 
+    def test_bracked_access_by_name(self):
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        
+        mix1_env = mme["case14_001"]                                          
+        assert mix1_env.name == "case14_001"
+        mix2_env = mme["case14_002"]
+        assert mix2_env.name == "case14_002"
+        with self.assertRaises(KeyError):
+            unknown_env = mme["unknwon_raise"]
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/grid2op/tests/test_MultiMix.py
+++ b/grid2op/tests/test_MultiMix.py
@@ -122,7 +122,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
         class DummyBackend(PandaPowerBackend):
             self._dummy = -1
 
-            def reset(self):
+            def reset(self, grid_path=None, grid_filename=None):
                 self._dummy = 1
                 
             def dummy(self):

--- a/grid2op/tests/test_MultiMix.py
+++ b/grid2op/tests/test_MultiMix.py
@@ -10,6 +10,7 @@ import tempfile
 
 from grid2op.tests.helper_path_test import *
 from grid2op.Environment import MultiMixEnvironment
+from grid2op.Environment import BaseEnv
 from grid2op.Observation import CompleteObservation
 from grid2op.Parameters import Parameters
 from grid2op.Reward import GameplayReward, L2RPNReward
@@ -228,7 +229,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert isinstance(info, dict)
         assert done is not True
 
-    def test_bracked_access_by_name(self):
+    def test_bracket_access_by_name(self):
         mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
         
         mix1_env = mme["case14_001"]                                          
@@ -236,8 +237,33 @@ class TestMultiMixEnvironment(unittest.TestCase):
         mix2_env = mme["case14_002"]
         assert mix2_env.name == "case14_002"
         with self.assertRaises(KeyError):
-            unknown_env = mme["unknwon_raise"]
+            unknown_env = mme["unknown_raise"]
 
+    def test_keys_access(self):
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+
+        for k in mme.keys():
+            mix = mme[k]
+            assert mix is not None
+            assert isinstance(mix, BaseEnv)
+            assert mix.name == k
+
+    def test_values_access(self):
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+
+        for v in mme.values():
+            assert v is not None
+            assert isinstance(v, BaseEnv)
+            assert v == mme[v.name]
+
+    def test_items_acces(self):
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+
+        for k,v in mme.items():
+            assert k is not None
+            assert v is not None
+            assert isinstance(v, BaseEnv)
+            assert v == mme[k]
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
 - Adds `operator[]` overload to access underlying mixes by name 
 - Adds dict like interface `keys`, `values`, `items` methods