### PR TITLE
Minor docstrings fix

### DIFF
--- a/grid2op/Action/BaseAction.py
+++ b/grid2op/Action/BaseAction.py
@@ -142,9 +142,10 @@ class BaseAction(GridObjects):
         bus connectivity at a substation. It has the same size as the full topological vector (:attr:`BaseAction._dim_topo`)
         and for each element it should be understood as:
 
-            - 0: nothing is changed for this element
-            - +1: this element is affected to bus 1
-            - -1: this element is affected to bus 2
+            - 0 -> don't change
+            - 1 -> connect to bus 1
+            - 2 -> connect to bus 2
+            - -1 -> disconnect the object.
 
     _change_bus_vect: :class:`numpy.ndarray`, dtype:bool
          Similar to :attr:`BaseAction._switch_line_status` but it affects the topology at substations instead of the status

--- a/grid2op/Observation/BaseObservation.py
+++ b/grid2op/Observation/BaseObservation.py
@@ -124,14 +124,14 @@ class BaseObservation(GridObjects):
 
     time_before_cooldown_line:  :class:`numpy.ndarray`, dtype:int
         For each powerline, it gives the number of time step the powerline is unavailable due to "cooldown"
-        (see :attr:`grid2op.Parameters.Parameters.NB_TIMESTEP_LINE_STATUS_REMODIF` for more information). 0 means the
+        (see :attr:`grid2op.Parameters.NB_TIMESTEP_COOLDOWN_LINE` for more information). 0 means the
         an action will be able to act on this same powerline, a number > 0 (eg 1) means that an action at this time step
         cannot act on this powerline (in the example the agent have to wait 1 time step)
 
     time_before_cooldown_sub: :class:`numpy.ndarray`, dtype:int
         Same as :attr:`BaseObservation.time_before_cooldown_line` but for substations. For each substation, it gives the
         number of timesteps to wait before acting on this substation (see
-        see :attr:`grid2op.Parameters.Parameters.NB_TIMESTEP_TOPOLOGY_REMODIF` for more information).
+        see :attr:`grid2op.Parameters.NB_TIMESTEP_COOLDOWN_SUB` for more information).
 
     time_next_maintenance: :class:`numpy.ndarray`, dtype:int
         For each powerline, it gives the time of the next planned maintenance. For example if there is:


### PR DESCRIPTION
 - Updates `Parameters` references in `BaseObservation`
 - Updates `_set_topo_vect` docstring in `BaseAction` so that its coherent with values set by `_digest_setbus`