### PR TITLE
Gym space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Change Log
 - [FIXED] `Issue #134 <https://github.com/rte-france/Grid2Op/issues/134>`_: Backend iadd actions with lines extremities disconnections (set -1)
 - [FIXED] issue `Issue #125 <https://github.com/rte-france/Grid2Op/issues/125>`_
 - [FIXED] issue `Issue #126 <https://github.com/rte-france/Grid2Op/issues/126>`_ Loading runner logs no longer checks environment actions ambiguity
+- [IMPROVED] issue `Issue #16 <https://github.com/rte-france/Grid2Op/issues/16>`_ improving openai gym integration.
+
 
 [1.1.1] - 2020-07-07
 ---------------------

--- a/grid2op/Converter/AnalogStateConverter.py
+++ b/grid2op/Converter/AnalogStateConverter.py
@@ -18,6 +18,10 @@ class AnalogStateConverter(Converter):
     
     The grid2op observation is converted into a 1d normalied array
     The grid2op action is created from a set of real valued arrays
+
+    It can not yet be converted to / from gym space. If this feature is interesting for you, you can
+    reply to the issue posted at https://github.com/rte-france/Grid2Op/issues/16
+    
     """
 
     def __init__(self, action_space, bias=0.0):

--- a/grid2op/Converter/ConnectivityConverter.py
+++ b/grid2op/Converter/ConnectivityConverter.py
@@ -21,6 +21,9 @@ class ConnectivityConverter(Converter):
     A and B", connect "B and C" but "**not connect** A and C" in this case you need an algorithm to disambuate your
     action.
 
+    It can not yet be converted to / from gym space. If this feature is interesting for you, you can
+    reply to the issue posted at https://github.com/rte-france/Grid2Op/issues/16
+
     **NB** compare to :class:`IdToAct` this converter allows for a smaller size. If you have N elements connected at
     a substation, you end up with `N*(N-1)/2` different action. Compare to IdToAct though, it is expected that your
     algorithm produces more than 1 output.

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -14,7 +14,6 @@ class Converter(ActionSpace):
     """
     def __init__(self, action_space):
         ActionSpace.__init__(self, action_space, action_space.legal_action, action_space.subtype)
-        # self.__class__ = Converter.init_grid(action_space)
         self.space_prng = action_space.space_prng
         self.seed_used = action_space.seed_used
 

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -76,11 +76,83 @@ class Converter(ActionSpace):
                                   "".format(self))
 
     def convert_action_from_gym(self, gymlike_action):
+        """
+        Convert the action (represented as a gym object, in fact an ordered dict) as an action
+        compatible with this converter.
+
+        This is not compatible with all converters and you need to install gym for it to work.
+
+        Parameters
+        ----------
+        gymlike_action:
+            the action to be converted to an action compatible with the action space representation
+
+        Returns
+        -------
+        res:
+            The action converted to be understandable by this converter.
+
+        Examples
+        ---------
+        Here is an example on how to use this feature with the :class:`grid2op.Converter.IdToAct`
+        converter (imports are not shown here).
+
+        .. code-block:: python
+
+            # create the environment
+            env = grid2op.make()
+
+            # create the converter
+            converter = IdToAct(env.action_space)
+
+            # create the gym action space
+            gym_action_space = GymObservationSpace(action_space=converter)
+
+            gym_action = gym_action_space.sample()
+            converter_action = converter.convert_action_from_gym(gym_action)  # this represents the same action
+            grid2op_action = converter.convert_act(converter_action)
+
+        """
         raise NotImplementedError("Impossible to convert the gym-like action automatically "
                                   "into the converter representation for \"{}\" "
                                   "".format(self))
 
-    def convert_action_to_gym(self, gymlike_action):
+    def convert_action_to_gym(self, action):
+        """
+        Convert the action (compatible with this converter) into a "gym action" (ie an OrderedDict)
+
+        This is not compatible with all converters and you need to install gym for it to work.
+
+        Parameters
+        ----------
+        action:
+            the action to be converted to an action compatible with the action space representation
+
+        Returns
+        -------
+        res:
+            The action converted to a "gym" model (can be used by a machine learning model)
+
+        Examples
+        ---------
+        Here is an example on how to use this feature with the :class:`grid2op.Converter.IdToAct`
+        converter (imports are not shown here).
+
+        .. code-block:: python
+
+            # create the environment
+            env = grid2op.make()
+
+            # create the converter
+            converter = IdToAct(env.action_space)
+
+            # create the gym action space
+            gym_action_space = GymObservationSpace(action_space=converter)
+
+            converter_action = converter.sample()
+            gym_action = converter.to_gym(converter_action)  # this represents the same action
+
+        """
         raise NotImplementedError("Impossible to convert the gym-like action automatically "
                                   "into the converter representation for \"{}\" "
                                   "".format(self))

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -63,13 +63,15 @@ class Converter(ActionSpace):
 
     def get_gym_dict(self):
         """
-        To convert this space into a open ai gym space.
+        To convert this space into a open ai gym space. This function returns a dictionnary used
+        to initialize such a converter.
 
-        # TODO
+        It should not be used directly. Prefer to use the :class:`grid2op.Converter.GymConverter`
 
         Returns
         -------
-
+        res: ``dict``
+            The dictionary of gym spaces representing this converter.
         """
         raise NotImplementedError("Impossible to convert the converter \"{}\" automatically "
                                   "into a gym space (or gym is not installed on your machine)."

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -60,3 +60,27 @@ class Converter(ActionSpace):
         """
         regular_act = encoded_act
         return regular_act
+
+    def get_gym_dict(self):
+        """
+        To convert this space into a open ai gym space.
+
+        # TODO
+
+        Returns
+        -------
+
+        """
+        raise NotImplementedError("Impossible to convert the converter \"{}\" automatically "
+                                  "into a gym space (or gym is not installed on your machine)."
+                                  "".format(self))
+
+    def convert_action_from_gym(self, gymlike_action):
+        raise NotImplementedError("Impossible to convert the gym-like action automatically "
+                                  "into the converter representation for \"{}\" "
+                                  "".format(self))
+
+    def convert_action_to_gym(self, gymlike_action):
+        raise NotImplementedError("Impossible to convert the gym-like action automatically "
+                                  "into the converter representation for \"{}\" "
+                                  "".format(self))

--- a/grid2op/Converter/GymConverter.py
+++ b/grid2op/Converter/GymConverter.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import numpy as np
+from grid2op.Converter.Converters import Converter
+from grid2op.Action import BaseAction
+from grid2op.Observation import BaseObservation
+from grid2op.dtypes import dt_int, dt_bool, dt_float
+from gym import spaces
+
+
+class BaseGymConverter:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def _generic_gym_space(dt, sh, low=None, high=None):
+        if low is None:
+            low = np.iinfo(dt).min
+        if high is None:
+            high = np.iinfo(dt).max
+        shape = (sh,)
+        my_type = spaces.Box(low=dt.type(low), high=dt.type(high), shape=shape, dtype=dt)
+        return my_type
+
+    @staticmethod
+    def _boolean_type(sh):
+        return spaces.MultiBinary(n=sh)
+
+    @staticmethod
+    def _extract_obj_grid2op(grid2op_obj, attr_nm, dtype):
+        res = grid2op_obj._get_array_from_attr_name(attr_nm)
+
+        if len(res) == 1:
+            res = res[0]
+            # convert the types for json serializable
+            # this is not automatically done by gym...
+            if dtype == dt_int or dtype == np.int64 or dtype == np.int32:
+                res = int(res)
+            elif dtype == dt_float or dtype == np.float64 or dtype == np.float32:
+                res = float(res)
+            elif dtype == dt_bool:
+                res = bool(res)
+        return res
+
+    def _base_to_gym(self, keys, obj, dtypes, converter=None):
+        res = spaces.dict.OrderedDict()
+        for k in keys:
+            conv_k = k
+            if converter is not None:
+                conv_k = converter[k]
+            res[k] = self._extract_obj_grid2op(obj, conv_k, dtypes[k])
+        return res
+
+
+class GymObservationSpace(spaces.Dict, BaseGymConverter):
+    # deals with the observation space (rather easy)
+    def __init__(self, env):
+        self.initial_obs_space = env.observation_space
+        dict_ = {}
+        self._fill_dict_obs_space(dict_, env.observation_space, env.parameters)
+        spaces.Dict.__init__(self, dict_)
+
+    def _fill_dict_obs_space(self, dict_, observation_space, env_params):
+        for attr_nm, sh, dt in zip(observation_space.attr_list_vect,
+                                   observation_space.shape,
+                                   observation_space.dtype):
+            my_type = None
+            shape = (sh,)
+            if dt == dt_int:
+                # discrete observation space
+                if attr_nm == "year":
+                    my_type = spaces.Discrete(n=2100)
+                elif attr_nm == "month":
+                    my_type = spaces.Discrete(n=13)
+                elif attr_nm == "day":
+                    my_type = spaces.Discrete(n=32)
+                elif attr_nm == "hour_of_day":
+                    my_type = spaces.Discrete(n=24)
+                elif attr_nm == "minute_of_hour":
+                    my_type = spaces.Discrete(n=60)
+                elif attr_nm == "day_of_week":
+                    my_type = spaces.Discrete(n=8)
+                elif attr_nm == "topo_vect":
+                    my_type = spaces.Box(low=0, high=2, shape=shape, dtype=dt)
+                elif attr_nm == "time_before_cooldown_line":
+                    my_type = spaces.Box(low=0,
+                                         high=max(env_params.NB_TIMESTEP_COOLDOWN_LINE,
+                                                  env_params.NB_TIMESTEP_RECONNECTION),
+                                         shape=shape,
+                                         dtype=dt)
+                elif attr_nm == "time_before_cooldown_sub":
+                    my_type = spaces.Box(low=0,
+                                         high=env_params.NB_TIMESTEP_COOLDOWN_SUB,
+                                         shape=shape,
+                                         dtype=dt)
+                elif attr_nm == "duration_next_maintenance" or attr_nm == "time_next_maintenance":
+                    # can be -1 if no maintenance, otherwise always positive
+                    my_type = self._generic_gym_space(dt, sh, low=-1)
+
+            elif dt == dt_bool:
+                # boolean observation space
+                my_type = self._boolean_type(sh)
+            else:
+                # continuous observation space
+                low = float("-inf")
+                high = float("inf")
+                shape = (sh,)
+                SpaceType = spaces.Box
+                if attr_nm == "prod_p":
+                    low = observation_space.gen_pmin
+                    high = observation_space.gen_pmax
+                    shape = None
+                elif attr_nm == "prod_v" or attr_nm == "load_v" or attr_nm == "v_or" or attr_nm == "v_ex":
+                    # voltages can't be negative
+                    low = 0.
+                elif attr_nm == "a_or" or attr_nm == "a_ex":
+                    # amps can't be negative
+                    low = 0.
+                elif attr_nm == "target_dispatch" or attr_nm == "actual_dispatch":
+                    low = np.min([observation_space.gen_pmin,
+                                  -observation_space.gen_pmax])
+                    high = np.max([-observation_space.gen_pmin,
+                                   +observation_space.gen_pmax])
+                my_type = SpaceType(low=low, high=high, shape=shape, dtype=dt)
+
+            if my_type is None:
+                # if nothing has been found in the specific cases above
+                my_type = self._generic_gym_space(dt, sh)
+
+            dict_[attr_nm] = my_type
+
+    def from_gym(self, gymlike_observation: spaces.dict.OrderedDict) -> BaseObservation:
+        res = self.initial_obs_space.get_empty_observation()
+        for k, v in gymlike_observation.items():
+            res._assign_attr_from_name(k, v)
+        return res
+
+    def to_gym(self, grid2op_observation: BaseObservation) -> spaces.dict.OrderedDict:
+        return self._base_to_gym(self.spaces.keys(), grid2op_observation,
+                                 dtypes={k: self.spaces[k].dtype for k in self.spaces})
+
+
+class GymActionSpace(spaces.Dict, BaseGymConverter):
+    # deals with the action space (it depends how it's encoded...)
+    keys_grid2op_2_human = {"prod_p": "prod_p",
+                            "prod_v": "prod_v",
+                            "load_p": "load_p",
+                            "load_q": "load_q",
+                            "_redispatch": "redispatch",
+                            "_set_line_status": "set_line_status",
+                            "_switch_line_status": "change_line_status",
+                            "_set_topo_vect": "set_bus",
+                            "_change_bus_vect": "change_bus",
+                            "_hazards": "hazards",
+                            "_maintenance": "maintenance",
+                            }
+    keys_human_2_grid2op = {v: k for k, v in keys_grid2op_2_human.items()}
+
+    def __init__(self, action_space):
+        self.initial_act_space = action_space
+        dict_ = {}
+        if isinstance(action_space, Converter):
+            # a converter allows to ... convert the data so they have specific gym space
+            dict_ = action_space.get_gym_dict()
+            self.__is_converter = True
+        else:
+            self._fill_dict_act_space(dict_, action_space)
+            dict_ = self._fix_dict_keys(dict_)
+            self.__is_converter = False
+
+        spaces.Dict.__init__(self, dict_)
+
+    def _fill_dict_act_space(self, dict_, action_space):
+        for attr_nm, sh, dt in zip(action_space.attr_list_vect,
+                                   action_space.shape,
+                                   action_space.dtype):
+            my_type = None
+            shape = (sh,)
+            if dt == dt_int:
+                # discrete action space
+                if attr_nm == "_set_line_status":
+                    my_type = spaces.Box(low=-1,
+                                         high=1,
+                                         shape=shape,
+                                         dtype=dt)
+                elif attr_nm == "_set_topo_vect":
+                    my_type = spaces.Box(low=-1,
+                                         high=2,
+                                         shape=shape,
+                                         dtype=dt)
+            elif dt == dt_bool:
+                # boolean observation space
+                my_type = self._boolean_type(sh)
+                # case for all "change" action and maintenance / hazards
+            else:
+                # continuous observation space
+                low = float("-inf")
+                high = float("inf")
+                shape = (sh,)
+                SpaceType = spaces.Box
+
+                if attr_nm == "prod_p":
+                    low = action_space.gen_pmin
+                    high = action_space.gen_pmax
+                    shape = None
+                elif attr_nm == "prod_v":
+                    # voltages can't be negative
+                    low = 0.
+                elif attr_nm == "_redispatch":
+                    # redispatch
+                    low = -action_space.gen_max_ramp_down
+                    high = action_space.gen_max_ramp_up
+                my_type = SpaceType(low=low, high=high, shape=shape, dtype=dt)
+
+            if my_type is None:
+                # if nothing has been found in the specific cases above
+                my_type = self._generic_gym_space(dt, sh)
+
+            dict_[attr_nm] = my_type
+
+    def _fix_dict_keys(self, dict_: dict) -> dict:
+        res = {}
+        for k, v in dict_.items():
+            res[self.keys_grid2op_2_human[k]] = v
+        return res
+
+    def from_gym(self, gymlike_action: spaces.dict.OrderedDict) -> object:
+        """
+        Transform a gym-like action (such as the output of "sample()") into a grid2op action
+
+        Parameters
+        ----------
+        gymlike_action
+
+        Returns
+        -------
+
+        """
+        if self.__is_converter:
+            res = self.initial_act_space.convert_action_from_gym(gymlike_action)
+        else:
+            res = self.initial_act_space()
+            for k, v in gymlike_action.items():
+                res._assign_attr_from_name(self.keys_human_2_grid2op[k], v)
+        return res
+
+    def to_gym(self, action: object) -> spaces.dict.OrderedDict:
+        """
+        Transform an action (non gym) into an action compatible with the gym Space.
+
+        Parameters
+        ----------
+        action
+
+        Returns
+        -------
+
+        """
+        if self.__is_converter:
+            res = self.initial_act_space.convert_action_to_gym(action)
+        else:
+            # in that case action should be an instance of grid2op BaseAction
+            assert isinstance(action, BaseAction), "impossible to convert an action not coming from grid2op"
+            res = self._base_to_gym(self.spaces.keys(), action,
+                                    dtypes={k: self.spaces[k].dtype for k in self.spaces},
+                                    converter=self.keys_human_2_grid2op)
+        return res

--- a/grid2op/Converter/IdToAct.py
+++ b/grid2op/Converter/IdToAct.py
@@ -345,14 +345,18 @@ class IdToAct(Converter):
 
     def get_gym_dict(self):
         """
-        Transform this converter into a dictionnary that can be used to initialized a gym.spaces.Dict
+        Transform this converter into a dictionary that can be used to initialized a :class:`gym.spaces.Dict`.
+        The converter is modeled as a "Discrete" gym space with as many elements as the number
+        of different actions handled by this converter.
+
+        This is available as the "action" keys of the spaces.Dict gym action space build from it.
 
         This function should not be used "as is", but rather through :class:`grid2op.Converter.GymConverter`
 
         Returns
         -------
         res: :class:`gym.spaces.Dict`
-            The
+            The dict
         """
         # lazy import gym
         from gym import spaces
@@ -399,8 +403,6 @@ class IdToAct(Converter):
         """
         res = gymlike_action["action"]
         if not isinstance(res, (int, dt_int, np.int, np.int64)):
-            import pdb
-            pdb.set_trace()
             raise RuntimeError("TODO")
         return int(res)
 
@@ -443,5 +445,3 @@ class IdToAct(Converter):
         from gym import spaces
         res = spaces.dict.OrderedDict({"action": int(action)})
         return res
-
-

--- a/grid2op/Converter/ToVect.py
+++ b/grid2op/Converter/ToVect.py
@@ -6,7 +6,9 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
+import numpy as np
 from grid2op.Converter.Converters import Converter
+from grid2op.dtypes import dt_float, dt_int
 
 
 class ToVect(Converter):
@@ -17,12 +19,30 @@ class ToVect(Converter):
 
     - `encoded_act` are numpy ndarray
     - `transformed_obs` are numpy ndarray
+    (read more about these concepts by looking at the documentation of :class:`grid2op.Converter.Converters`)
 
+    It is convertible to a gym representation (like the original action space) in the form of a spaces.Box
+    representing a coutinuous action space (even though most component are probably discrete).
+    Note that if converted to a gym space, it is unlikely the method "sample" will yield to valid results.
+    Most of the time it should generate Ambiguous action that will not be handled by grid2op.
+
+    **NB** the conversion to a gym space should be done thanks to the :class:`grid2op.Converter.GymActionSpace`.
     """
     def __init__(self, action_space):
         Converter.__init__(self, action_space)
+        self.init_action_space = action_space
         self.__class__ = ToVect.init_grid(action_space)
         self.do_nothing_vect = action_space({}).to_vect()
+
+        # for gym conversion
+        self.__gym_action_space = None
+        self.__dict_space = None
+        self.__order_gym = None
+        self.__dtypes_gym = None
+        self.__shapes_gym = None
+
+        self.__order_gym_2_me = None
+        self.__order_me_2_gym = None
 
     def convert_obs(self, obs):
         """
@@ -59,5 +79,88 @@ class ToVect(Converter):
 
         """
         res = self.__call__({})
-        res.from_vect(encoded_act)
+        res.from_vect(encoded_act, check_legit=False)
+        return res
+
+    def _init_gym_converter(self):
+        if self.__gym_action_space is None:
+            # lazy import
+            from grid2op.Converter.GymConverter import GymActionSpace
+            from gym import spaces
+            # i do that not to duplicate the code of the low / high bounds
+            gym_action_space = GymActionSpace(self.init_action_space)
+            low = tuple()
+            high = tuple()
+            order_gym = []
+            dtypes = []
+            shapes = []
+            sizes = []
+            prev = 0
+            for k, v in gym_action_space.spaces.items():
+                order_gym.append(k)
+                dtypes.append(v.dtype)
+                if isinstance(v, spaces.MultiBinary):
+                    low += tuple([0 for _ in range(v.n)])
+                    high += tuple([1 for _ in range(v.n)])
+                    my_size = v.n
+                elif isinstance(v, spaces.Box):
+                    low += tuple(v.low)
+                    high += tuple(v.high)
+                    my_size = v.low.shape[0]
+                else:
+                    raise RuntimeError("Impossible to convert this converter to gym. Type {} of data " 
+                                       "encountered while only MultiBinary and Box are supported for now.")
+                shapes.append(my_size)
+                sizes.append(np.arange(my_size) + prev)
+                prev += my_size
+            self.__gym_action_space = gym_action_space
+            my_type = spaces.Box(low=np.array(low),
+                                 high=np.array(high),
+                                 dtype=dt_float)
+
+            order_me = []
+            _order_gym_2_me = np.zeros(my_type.shape[0], dtype=dt_int) - 1
+            _order_me_2_gym = np.zeros(my_type.shape[0], dtype=dt_int) - 1
+            for el in self.init_action_space.attr_list_vect:
+                order_me.append(GymActionSpace.keys_grid2op_2_human[el])
+
+            prev = 0
+            order_gym = list(gym_action_space.spaces.keys())
+            for id_me, nm_attr in enumerate(order_me):
+                id_gym = order_gym.index(nm_attr)
+                index_me = np.arange(shapes[id_gym]) + prev
+                _order_gym_2_me[sizes[id_gym]] = index_me
+                _order_me_2_gym[index_me] = sizes[id_gym]
+                # self.__order_gym_2_me[this_gym_ind] = sizes[id_me]
+                prev += shapes[id_gym]
+            self.__order_gym_2_me = _order_gym_2_me
+            self.__order_me_2_gym = _order_me_2_gym
+            self.__dict_space = {"action": my_type}
+            self.__order_gym = order_gym
+            self.__dtypes_gym = dtypes
+            self.__shapes_gym = shapes
+
+    def get_gym_dict(self):
+        """
+        Convert this action space int a "gym" action space represented by a dictionary (spaces.Dict)
+        This dictionary counts only one keys which is "action" and inside this action is the
+        """
+        self._init_gym_converter()
+        return self.__dict_space
+
+    def convert_action_from_gym(self, gymlike_action):
+        """
+        Convert a gym-like action (ie a Ordered dictionary with one key being only "action") to an
+        action compatible with this converter (in this case a vectorized action).
+        """
+        vect = gymlike_action["action"]
+        return vect[self.__order_gym_2_me]
+
+    def convert_action_to_gym(self, action):
+        """
+        Convert a an action of this converter (ie a numpy array) into an action that is usable with
+        an open ai gym (ie a Ordered dictionary with one key being only "action")
+        """
+        from gym import spaces
+        res = spaces.dict.OrderedDict({"action": action[self.__order_me_2_gym]})
         return res

--- a/grid2op/Converter/__init__.py
+++ b/grid2op/Converter/__init__.py
@@ -11,3 +11,11 @@ from grid2op.Converter.ToVect import ToVect
 from grid2op.Converter.IdToAct import IdToAct
 from grid2op.Converter.AnalogStateConverter import AnalogStateConverter
 from grid2op.Converter.ConnectivityConverter import ConnectivityConverter
+
+try:
+    from grid2op.Converter.GymConverter import GymObservationSpace, GymActionSpace
+    __all__.append("GymObservationSpace")
+    __all__.append("GymActionSpace")
+except ImportError:
+    # you must install open ai gym to benefit from this converter
+    pass

--- a/grid2op/Observation/CompleteObservation.py
+++ b/grid2op/Observation/CompleteObservation.py
@@ -142,9 +142,9 @@ class CompleteObservation(BaseObservation):
         self.day_of_week = dt_int(env.time_stamp.weekday())
 
         # get the values related to topology
-        self.timestep_overflow = copy.copy(env.timestep_overflow)
-        self.line_status = copy.copy(env.backend.get_line_status())
-        self.topo_vect = copy.copy(env.backend.get_topo_vect())
+        self.timestep_overflow[:] = env.timestep_overflow
+        self.line_status[:] = env.backend.get_line_status()
+        self.topo_vect[:] = env.backend.get_topo_vect()
 
         # get the values related to continuous values
         self.prod_p[:], self.prod_q[:], self.prod_v[:] = env.backend.generators_info()
@@ -167,7 +167,7 @@ class CompleteObservation(BaseObservation):
             self._forecasted_inj += env.chronics_handler.forecasts()
             self._forecasted_grid = [None for _ in self._forecasted_inj]
 
-        self.rho = env.backend.get_relative_flow().astype(dt_float)
+        self.rho[:] = env.backend.get_relative_flow().astype(dt_float)
 
         # cool down and reconnection time after hard overflow, soft overflow or cascading failure
         self.time_before_cooldown_line[:] = env.times_before_line_status_actionable

--- a/grid2op/Observation/ObservationSpace.py
+++ b/grid2op/Observation/ObservationSpace.py
@@ -130,3 +130,7 @@ class ObservationSpace(SerializableObservationSpace):
         :return:
         """
         return self.n
+
+    def get_empty_observation(self):
+        """return an empty observation, for internal use only."""
+        return copy.deepcopy(self._empty_obs)

--- a/grid2op/Space/SerializableSpace.py
+++ b/grid2op/Space/SerializableSpace.py
@@ -83,6 +83,7 @@ class SerializableSpace(GridObjects, RandomObject):
 
         self.shape = self._template_obj.shape()
         self.dtype = self._template_obj.dtype()
+        self.attr_list_vect = self._template_obj.attr_list_vect
 
         self._to_extract_vect = {}  # key: attr name, value: tuple: (beg_, end_, dtype)
         beg_ = 0

--- a/grid2op/tests/test_GymConverter.py
+++ b/grid2op/tests/test_GymConverter.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+# TODO test the json part but... https://github.com/openai/gym-http-api/issues/62 or https://github.com/openai/gym/issues/1841
+import tempfile
+import json
+import tempfile
+import json
+import warnings
+from grid2op.dtypes import dt_float, dt_bool, dt_int
+from grid2op.tests.helper_path_test import *
+from grid2op.MakeEnv import make
+from grid2op.Converter import GymActionSpace, GymObservationSpace
+
+import pdb
+
+
+class TestWithoutConverter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tol = 1e-6
+
+    def test_creation(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                # test i can create
+                obs_space = GymObservationSpace(env)
+                act_space = GymActionSpace(env.action_space)
+
+    def _aux_test_json(self, space, obj=None):
+        if obj is None:
+            obj = space.sample()
+        obj_json = space.to_jsonable([obj])
+        # test save to json
+        with tempfile.TemporaryFile(mode="w") as f:
+            json.dump(obj_json, fp=f)
+
+        # test read from json
+        obj2 = space.from_jsonable(obj_json)[0]
+
+        # test they are equal
+        for k, v in obj2.items():
+            assert k in obj
+            tmp = obj[k]
+            if isinstance(tmp, (int, float, dt_float, dt_int, dt_bool)):
+                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
+            elif len(tmp) == 1:
+                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
+            else:
+                assert np.all(np.abs(obj[k].astype(dt_float) - obj2[k].astype(dt_float)) <= self.tol)
+        for k, v in obj.items():
+            assert k in obj2  # make sure every keys of obj are in obj2
+
+    def test_json(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                # test i can create
+                obs_space = GymObservationSpace(env)
+                act_space = GymActionSpace(env.action_space)
+
+                obs_space.seed(0)
+                act_space.seed(0)
+
+                self._aux_test_json(obs_space)
+                self._aux_test_json(act_space)
+
+    def test_to_from_gym_obs(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                obs_space = GymObservationSpace(env)
+
+                obs = env.reset()
+                gym_obs = obs_space.to_gym(obs)
+                self._aux_test_json(obs_space, gym_obs)
+                assert obs_space.contains(gym_obs)
+                obs2 = obs_space.from_gym(gym_obs)
+                assert obs == obs2
+
+                for i in range(10):
+                    obs, *_ = env.step(env.action_space())
+                    gym_obs = obs_space.to_gym(obs)
+                    self._aux_test_json(obs_space, gym_obs)
+                    assert obs_space.contains(gym_obs), "gym space does not contain the observation for ts {}".format(i)
+                    obs2 = obs_space.from_gym(gym_obs)
+                    assert obs == obs2, "obs and converted obs are not equal for ts {}".format(i)
+
+    def test_to_from_gym_act(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                act_space = GymActionSpace(env.action_space)
+
+                act = env.action_space()
+                gym_act = act_space.to_gym(act)
+                self._aux_test_json(act_space, gym_act)
+                assert act_space.contains(gym_act)
+                act2 = act_space.from_gym(gym_act)
+                assert act == act2
+
+                act_space.seed(0)
+                for i in range(10):
+                    gym_act = act_space.sample()
+                    act = act_space.from_gym(gym_act)
+                    self._aux_test_json(act_space, gym_act)
+                    gym_act2 = act_space.to_gym(act)
+                    act2 = act_space.from_gym(gym_act2)
+                    assert act == act2

--- a/grid2op/tests/test_GymConverter.py
+++ b/grid2op/tests/test_GymConverter.py
@@ -20,17 +20,9 @@ from grid2op.Converter import GymActionSpace, GymObservationSpace, IdToAct
 import pdb
 
 
-class TestWithoutConverter(unittest.TestCase):
-    def setUp(self) -> None:
+class BaseTestGymConverter:
+    def __init__(self):
         self.tol = 1e-6
-
-    def test_creation(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            with make("l2rpn_wcci_2020", test=True) as env:
-                # test i can create
-                obs_space = GymObservationSpace(env)
-                act_space = GymActionSpace(env.action_space)
 
     def _aux_test_json(self, space, obj=None):
         if obj is None:
@@ -55,6 +47,19 @@ class TestWithoutConverter(unittest.TestCase):
                 assert np.all(np.abs(obj[k].astype(dt_float) - obj2[k].astype(dt_float)) <= self.tol)
         for k, v in obj.items():
             assert k in obj2  # make sure every keys of obj are in obj2
+
+
+class TestWithoutConverter(unittest.TestCase, BaseTestGymConverter):
+    def setUp(self) -> None:
+        BaseTestGymConverter.__init__(self)
+
+    def test_creation(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                # test i can create
+                obs_space = GymObservationSpace(env)
+                act_space = GymActionSpace(env.action_space)
 
     def test_json(self):
         with warnings.catch_warnings():
@@ -114,10 +119,10 @@ class TestWithoutConverter(unittest.TestCase):
                     assert act == act2
 
 
-class TestIdToAct(unittest.TestCase):
+class TestIdToAct(unittest.TestCase, BaseTestGymConverter):
     def setUp(self) -> None:
-        self.tol = 1e-6
-
+        BaseTestGymConverter.__init__(self)
+        
     def test_creation(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
@@ -125,30 +130,7 @@ class TestIdToAct(unittest.TestCase):
                 # test i can create
                 idtoact = IdToAct(env.action_space)
                 act_space = GymActionSpace(idtoact)
-
-    def _aux_test_json(self, space, obj=None):
-        if obj is None:
-            obj = space.sample()
-        obj_json = space.to_jsonable([obj])
-        # test save to json
-        with tempfile.TemporaryFile(mode="w") as f:
-            json.dump(obj_json, fp=f)
-
-        # test read from json
-        obj2 = space.from_jsonable(obj_json)[0]
-
-        # test they are equal
-        for k, v in obj2.items():
-            assert k in obj
-            tmp = obj[k]
-            if isinstance(tmp, (int, float, dt_float, dt_int, dt_bool)):
-                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
-            elif len(tmp) == 1:
-                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
-            else:
-                assert np.all(np.abs(obj[k].astype(dt_float) - obj2[k].astype(dt_float)) <= self.tol)
-        for k, v in obj.items():
-            assert k in obj2  # make sure every keys of obj are in obj2
+                act_space.sample()
 
     def test_json(self):
         with warnings.catch_warnings():

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ pkgs = {
             "seaborn>=0.10.0",
             "imageio>=2.8.0",
             "pygifsicle>=1.0.1",
-            "psutil>=5.7.0"
+            "psutil>=5.7.0",
+            "gym>=0.17.1",
         ],
         "challenge": [
             "numpy==1.18.3",


### PR DESCRIPTION
Improve on issue #16 

The following improvements are made:
- standard observation space is convertible to a spaces.Dict (keys: the attributes name of the observation, values: the corresponding attribute value in a form of a spaces.Discrete, spaces.Box or spaces.MultiBinary depending on the attribute)
-  standard observation space is convertible to a spaces.Dict (keys: the attributes name of the action, values: the corresponding attribute value in a form of a spaces.Discrete, spaces.Box or spaces.MultiBinary depending on the attribute)
- IdToAct converter is convertible into a gym spaces.Dict (with key "action" of type  spaces.Discrete)
- ToVect converter is convertible into a gym spaces.Dict (with key "action" of type spaces.Box)