### PR TITLE
Fix ID's in prevent reconnection rules again

### DIFF
--- a/grid2op/Rules/PreventReconnection.py
+++ b/grid2op/Rules/PreventReconnection.py
@@ -39,12 +39,12 @@ class PreventReconnection(BaseRules):
         if np.any(env.times_before_line_status_actionable[aff_lines] > 0):
             # i tried to act on a powerline too shortly after a previous action
             # or shut down due to an overflow or opponent or hazards or maintenance
-            ids = np.where(env.times_before_line_status_actionable[aff_lines] > 0)[0]
+            ids = np.logical_and(env.times_before_line_status_actionable[aff_lines] > 0, aff_lines).nonzero()[0]
             return False, IllegalAction("Powerline with ids {} have been modified illegally (cooldown)".format(ids))
 
         if np.any(env.times_before_topology_actionable[aff_subs] > 0):
             # I tried to act on a topology too shortly after a previous action
-            ids = np.where(env.times_before_line_status_actionable[aff_lines] > 0)[0]
+            ids = np.logical_and(env.times_before_topology_actionable[aff_subs] > 0, aff_subs).nonzero()[0]
             return False, IllegalAction("Substation with ids {} have been modified illegally (cooldown)".format(ids))
 
         return True, None

--- a/grid2op/Rules/PreventReconnection.py
+++ b/grid2op/Rules/PreventReconnection.py
@@ -39,12 +39,12 @@ class PreventReconnection(BaseRules):
         if np.any(env.times_before_line_status_actionable[aff_lines] > 0):
             # i tried to act on a powerline too shortly after a previous action
             # or shut down due to an overflow or opponent or hazards or maintenance
-            ids = np.logical_and(env.times_before_line_status_actionable[aff_lines] > 0, aff_lines).nonzero()[0]
+            ids = np.logical_and(env.times_before_line_status_actionable > 0, aff_lines).nonzero()[0]
             return False, IllegalAction("Powerline with ids {} have been modified illegally (cooldown)".format(ids))
 
         if np.any(env.times_before_topology_actionable[aff_subs] > 0):
             # I tried to act on a topology too shortly after a previous action
-            ids = np.logical_and(env.times_before_topology_actionable[aff_subs] > 0, aff_subs).nonzero()[0]
+            ids = np.logical_and(env.times_before_topology_actionable > 0, aff_subs).nonzero()[0]
             return False, IllegalAction("Substation with ids {} have been modified illegally (cooldown)".format(ids))
 
         return True, None


### PR DESCRIPTION
I made a mistake in my PR yesterday. If the number of lines or substations is greater then one then a size mismatch exception is thrown. This fixes the issue and is what I originally intended.

I am making this a draft request as I plan to add a proper test tomorrow.