### PR TITLE
Adding a few features and fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,6 +305,7 @@ test_issue185.py
 test_can_make_opponent.py
 enigma_nili.py
 test_issue196.py
+test_increasingreward.py
 
 # profiling files
 **.prof

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,11 +30,13 @@ Change Log
 - [FIXED]: `Issue#196 <https://github.com/rte-france/Grid2Op/issues/196>`_ an issue related the scaling when negative
   numbers are used (in these cases low / max would be mixed up)
 - [FIXED]: an issue with the `IncreasingFlatReward` reward types
+- [ADDED]: a reward `EpisodeDurationReward` that is always 0 unless at the end of an episode where it returns a float
+  proportional to the number of step made from the beginning of the environment.
 - [IMPROVED]: on windows at least, grid2op does not work with gym < 0.17.2 Checks are performed in order to make sure
   the installed open ai gym package meets this requirement (see issue
   `Issue#185 <https://github.com/rte-france/Grid2Op/issues/185>`_ )
 - [IMPROVED] the seed of openAI gym for composed action space (see issue `https://github.com/openai/gym/issues/2166`):
-  waiting for an official fix, grid2op will use the solution proposed there
+  in waiting for an official fix, grid2op will use the solution proposed there
   https://github.com/openai/gym/issues/2166#issuecomment-803984619 )
 
 [1.5.1] - 2021-04-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,11 @@ Change Log
 
 [1.5.2] - 2021-xx-yy
 -----------------------
+- [BREAKING]: allow the opponent to chose the duration of its attack. This breaks the previous "Opponent.attack(...)"
+  signature by adding an object in the return value. All code provided with grid2op are compatible with this
+  new change. (for previously coded opponent, the only thing you have to do to make it compliant with
+  the new interface is, in the `opponent.attack(...)` function return `whatever_you_returned_before, None` instead
+  of simply `whatever_you_returned_before`
 - [FIXED]: `Issue#196 <https://github.com/rte-france/Grid2Op/issues/196>`_ an issue related to the
   low / high of the observation if using the gym_compat module. Some more protections
   are enforced now.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Change Log
 - [FIXED]: an issue with the `IncreasingFlatReward` reward types
 - [ADDED]: a reward `EpisodeDurationReward` that is always 0 unless at the end of an episode where it returns a float
   proportional to the number of step made from the beginning of the environment.
+- [ADDED]: in the `Observation` the possibility to retrieve the current number of steps
 - [IMPROVED]: on windows at least, grid2op does not work with gym < 0.17.2 Checks are performed in order to make sure
   the installed open ai gym package meets this requirement (see issue
   `Issue#185 <https://github.com/rte-france/Grid2Op/issues/185>`_ )

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Change Log
   are enforced now.
 - [FIXED]: `Issue#196 <https://github.com/rte-france/Grid2Op/issues/196>`_ an issue related the scaling when negative
   numbers are used (in these cases low / max would be mixed up)
+- [FIXED]: an issue with the `IncreasingFlatReward` reward types
 - [IMPROVED]: on windows at least, grid2op does not work with gym < 0.17.2 Checks are performed in order to make sure
   the installed open ai gym package meets this requirement (see issue
   `Issue#185 <https://github.com/rte-france/Grid2Op/issues/185>`_ )

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -379,6 +379,9 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         self._sum_curtailment_mw = None
         self._sum_curtailment_mw_prev = None
 
+        # count number of steps properly performed
+        self._current_time_step = 0
+
     @property
     def action_space(self):
         """this represent a view on the action space"""
@@ -1551,6 +1554,8 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         lines_attacked, subs_attacked = None, None
         conv_ = None
         init_line_status = copy.deepcopy(self.backend.get_line_status())
+        self._current_time_step += 1
+
         beg_step = time.time()
         try:
             beg_ = time.time()
@@ -1852,6 +1857,8 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         # reward and others
         self.current_reward = self.reward_range[0]
         self.done = False
+
+        self._current_time_step = 0
 
     def _reset_maintenance(self):
         self._time_next_maintenance[:] = -1

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -379,9 +379,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         self._sum_curtailment_mw = None
         self._sum_curtailment_mw_prev = None
 
-        # count number of steps properly performed
-        self._current_time_step = 0
-
     @property
     def action_space(self):
         """this represent a view on the action space"""
@@ -1554,7 +1551,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         lines_attacked, subs_attacked = None, None
         conv_ = None
         init_line_status = copy.deepcopy(self.backend.get_line_status())
-        self._current_time_step += 1
 
         beg_step = time.time()
         try:
@@ -1857,8 +1853,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         # reward and others
         self.current_reward = self.reward_range[0]
         self.done = False
-
-        self._current_time_step = 0
 
     def _reset_maintenance(self):
         self._time_next_maintenance[:] = -1

--- a/grid2op/Environment/Environment.py
+++ b/grid2op/Environment/Environment.py
@@ -244,13 +244,6 @@ class Environment(BaseEnv):
                                                             actionClass=CompleteAction,
                                                             legal_action=self._game_rules.legal_action)
 
-        self._helper_observation_class = ObservationSpace.init_grid(gridobj=bk_type)
-        self._observation_space = self._helper_observation_class(gridobj=bk_type,
-                                                                 observationClass=observationClass,
-                                                                 actionClass=actionClass,
-                                                                 rewardClass=rewardClass,
-                                                                 env=self)
-
         # handles input data
         if not isinstance(chronics_handler, ChronicsHandler):
             raise Grid2OpException(
@@ -262,6 +255,15 @@ class Environment(BaseEnv):
                                          self.name_line, self.name_sub,
                                          names_chronics_to_backend=names_chronics_to_backend)
         self.names_chronics_to_backend = names_chronics_to_backend
+
+        # this needs to be done after the chronics handler: rewards might need information
+        # about the chronics to work properly.
+        self._helper_observation_class = ObservationSpace.init_grid(gridobj=bk_type)
+        self._observation_space = self._helper_observation_class(gridobj=bk_type,
+                                                                 observationClass=observationClass,
+                                                                 actionClass=actionClass,
+                                                                 rewardClass=rewardClass,
+                                                                 env=self)
 
         # test to make sure the backend is consistent with the chronics generator
         self.chronics_handler.check_validity(self.backend)

--- a/grid2op/Observation/BaseObservation.py
+++ b/grid2op/Observation/BaseObservation.py
@@ -188,6 +188,9 @@ class BaseObservation(GridObjects):
     curtailment_limit: :class:`numpy.ndarray`, dtype:float
         Limit (in ratio of gen_pmax) imposed on each renewable generator.
 
+    current_step: ``int``
+        Current number of step performed up until this observation (NB this is not given in the observation if
+        it is transformed into a vector)
     """
 
     _attr_eq = ["line_status",
@@ -315,6 +318,9 @@ class BaseObservation(GridObjects):
         self.load_theta = np.empty(shape=self.n_load, dtype=dt_float)
         self.gen_theta = np.empty(shape=self.n_gen, dtype=dt_float)
         self.storage_theta = np.empty(shape=self.n_storage, dtype=dt_float)
+
+        # counter
+        self.current_step = 0
 
     def state_of(self,
                  _sentinel=None,

--- a/grid2op/Observation/CompleteObservation.py
+++ b/grid2op/Observation/CompleteObservation.py
@@ -130,6 +130,9 @@ class CompleteObservation(BaseObservation):
         self._reset_matrices()
         self.reset()
 
+        # counter
+        self.current_step = env.nb_time_step
+
         # extract the time stamps
         self.year = dt_int(env.time_stamp.year)
         self.month = dt_int(env.time_stamp.month)

--- a/grid2op/Observation/_ObsEnv.py
+++ b/grid2op/Observation/_ObsEnv.py
@@ -123,6 +123,9 @@ class _ObsEnv(BaseEnv):
         self._sum_curtailment_mw_init = 0.
         self._sum_curtailment_mw_prev_init = 0.
 
+        # step count
+        self._nb_time_step_init = 0
+
     def _init_myclass(self):
         """this class has already all the powergrid information: it is initialized in the obs space !"""
         pass
@@ -363,6 +366,9 @@ class _ObsEnv(BaseEnv):
         self._sum_curtailment_mw = self._sum_curtailment_mw_init
         self._sum_curtailment_mw_prev = self._sum_curtailment_mw_prev_init
 
+        # current step
+        self.nb_time_step = self._nb_time_step_init
+
     def simulate(self, action):
         """
         INTERNAL
@@ -489,6 +495,9 @@ class _ObsEnv(BaseEnv):
 
         # time delta
         self.delta_time_seconds = env.delta_time_seconds
+
+        # current time
+        self._nb_time_step_init = env.nb_time_step
 
     def get_current_line_status(self):
         return self._line_status == 1

--- a/grid2op/Opponent/BaseOpponent.py
+++ b/grid2op/Opponent/BaseOpponent.py
@@ -68,10 +68,14 @@ class BaseOpponent(RandomObject):
         -------
         attack: :class:`grid2op.Action.Action`
             The attack performed by the opponent. In this case, a do nothing, all the time.
+
+        duration: ``int``
+            The duration of the attack
+
         """
         # TODO maybe have a class "GymOpponent" where the observation would include the budget  and all other
         # TODO information, and forward something to the "act" method.
-        return None
+        return None, None
 
     def tell_attack_continues(self, observation, agent_action, env_action, budget):
         """

--- a/grid2op/Opponent/RandomLineOpponent.py
+++ b/grid2op/Opponent/RandomLineOpponent.py
@@ -108,20 +108,23 @@ class RandomLineOpponent(BaseOpponent):
         -------
         attack: :class:`grid2op.Action.Action`
             The attack performed by the opponent. In this case, a do nothing, all the time.
+
+        duration: ``int``
+            The duration of the attack (if ``None`` then the attack will be made for the longest allowed time)
         """
         # TODO maybe have a class "GymOpponent" where the observation would include the budget  and all other
         # TODO information, and forward something to the "act" method.
 
         if observation is None:  # during creation of the environment
-            return None  # i choose not to attack in this case
+            return None, 0  # i choose not to attack in this case
 
         # Status of attackable lines
         status = observation.line_status[self._lines_ids]
 
         # If all attackable lines are disconnected
         if np.all(~status):
-            return None  # i choose not to attack in this case
+            return None, 0  # i choose not to attack in this case
 
         # Pick a line among the connected lines
         attack = self.space_prng.choice(self._attacks[status])
-        return attack
+        return attack, None

--- a/grid2op/Opponent/WeightedRandomOpponent.py
+++ b/grid2op/Opponent/WeightedRandomOpponent.py
@@ -135,13 +135,16 @@ class WeightedRandomOpponent(BaseOpponent):
         -------
         attack: :class:`grid2op.Action.Action`
             The attack performed by the opponent. In this case, a do nothing, all the time.
+
+        duration: ``int``
+            The duration of the attack
         """
         # TODO maybe have a class "GymOpponent" where the observation would include the budget  and all other
         # TODO information, and forward something to the "act" method.
 
         # During creation of the environment, do not attack
         if observation is None:
-            return None
+            return None, 0
 
         # Decide the time of the next attack
         if self._next_attack_time is None:
@@ -150,16 +153,17 @@ class WeightedRandomOpponent(BaseOpponent):
 
         # If the attack time has not come yet, do not attack
         if self._next_attack_time > 0:
-            return None
+            return None, 0
 
         # If all attackable lines are disconnected, do not attack
         status = observation.line_status[self._lines_ids]
         if np.all(~status):
-            return None
+            return None, 0
+
         available_attacks = self._attacks[status]
         rho = observation.rho[self._lines_ids][status] / self._rho_normalization[status]
         rho_sum = rho.sum()
         if rho_sum <= 0.:
             return None
         attack = self.space_prng.choice(available_attacks, p=rho / rho_sum)
-        return attack
+        return attack, None

--- a/grid2op/Reward/IncreasingFlatReward.py
+++ b/grid2op/Reward/IncreasingFlatReward.py
@@ -49,7 +49,7 @@ class IncreasingFlatReward(BaseReward):
 
     def __call__(self, action, env, has_error, is_done, is_illegal, is_ambiguous):
         if not has_error:
-            res = dt_float(env._nb_time_step * self.per_timestep)
+            res = dt_float(env._current_time_step * self.per_timestep)
         else:
             res = self.reward_min
         return res

--- a/grid2op/Reward/__init__.py
+++ b/grid2op/Reward/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "CombinedScaledReward",
     "RewardHelper",
     "BaseReward",
+    "EpisodeDurationReward",
     # TODO it would be better to have a specific package for this, but in the mean time i put it here
     "L2RPNSandBoxScore"
 ]
@@ -36,6 +37,7 @@ from grid2op.Reward.CombinedScaledReward import CombinedScaledReward
 from grid2op.Reward.RewardHelper import RewardHelper
 from grid2op.Reward.BaseReward import BaseReward
 from grid2op.Reward.L2RPNSandBoxScore import L2RPNSandBoxScore
+from grid2op.Reward.EpisodeDurationReward import EpisodeDurationReward
 
 import warnings
 

--- a/grid2op/gym_compat/gym_obs_space.py
+++ b/grid2op/gym_compat/gym_obs_space.py
@@ -159,7 +159,7 @@ class GymObservationSpace(_BaseGymSpaceConverter):
                     my_type = spaces.Box(low=0,
                                          high=max(env_params.NB_TIMESTEP_COOLDOWN_LINE,
                                                   env_params.NB_TIMESTEP_RECONNECTION,
-                                                  opponent_space.attack_duration
+                                                  opponent_space.attack_max_duration
                                                   ),
                                          shape=shape,
                                          dtype=dt)

--- a/grid2op/tests/test_Observation.py
+++ b/grid2op/tests/test_Observation.py
@@ -1428,6 +1428,30 @@ class TestSimulateEqualsStep(unittest.TestCase):
         assert abs(rew1 - rew3) <= 1e-8, "issue with reward"
         self._check_equal(sim_obs1, sim_obs3)
 
+    def test_nb_step(self):
+        obs = self.env.reset()
+        sim_obs1, rew1, done1, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
+        sim_obs2, rew2, done2, _ = obs.simulate(self.env.action_space(), time_step=0)
+        sim_obs3, rew3, done3, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
+        assert obs.current_step == 0
+        assert sim_obs1.current_step == 1
+        assert sim_obs2.current_step == 1
+        assert sim_obs3.current_step == 1
+
+        obs, *_ = self.env.step(self.env.action_space())
+        sim_obs1, rew1, done1, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
+        assert obs.current_step == 1
+        assert sim_obs1.current_step == 2
+        
+        obs = self.env.reset()
+        sim_obs1, rew1, done1, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
+        sim_obs2, rew2, done2, _ = obs.simulate(self.env.action_space(), time_step=0)
+        sim_obs3, rew3, done3, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
+        assert obs.current_step == 0
+        assert sim_obs1.current_step == 1
+        assert sim_obs2.current_step == 1
+        assert sim_obs3.current_step == 1
+
 
 class TestSimulateEqualsStepStorageCurtail(TestSimulateEqualsStep):
     def setUp(self):

--- a/grid2op/tests/test_Observation.py
+++ b/grid2op/tests/test_Observation.py
@@ -1442,7 +1442,7 @@ class TestSimulateEqualsStep(unittest.TestCase):
         sim_obs1, rew1, done1, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
         assert obs.current_step == 1
         assert sim_obs1.current_step == 2
-        
+
         obs = self.env.reset()
         sim_obs1, rew1, done1, _ = obs.simulate(self.env.action_space.disconnect_powerline(line_id=2))
         sim_obs2, rew2, done2, _ = obs.simulate(self.env.action_space(), time_step=0)

--- a/grid2op/tests/test_Opponent.py
+++ b/grid2op/tests/test_Opponent.py
@@ -46,7 +46,7 @@ class TestSuiteOpponent_001(BaseOpponent):
         if observation is None:  # On first step
             return None
         attack = self.space_prng.choice(self.possible_attack)
-        return attack
+        return attack, None
 
 
 class TestWeightedRandomOpponent(WeightedRandomOpponent):
@@ -184,7 +184,7 @@ class TestLoadingOpp(unittest.TestCase):
                 obs = env.reset()
                 assert env._oppSpace.budget == init_budget
                 # The opponent can attack
-                for i in range(env._oppSpace.attack_duration):
+                for i in range(env._oppSpace.attack_max_duration):
                     obs, reward, done, info = env.step(env.action_space())
                     attack = env._oppSpace.last_attack
                     assert env._oppSpace.budget == init_budget - i - 1
@@ -427,7 +427,7 @@ class TestLoadingOpp(unittest.TestCase):
                     
                 attack = env._oppSpace.last_attack
                 attacked_line = np.where(attack._set_line_status == -1)[0][0]
-                if env._oppSpace.current_attack_duration < env._oppSpace.attack_duration:
+                if env._oppSpace.current_attack_duration < env._oppSpace.attack_max_duration:
                     # The attack is ungoing. The line must have been disconnected already
                     assert not pre_obs.line_status[attacked_line]
                 else:
@@ -755,7 +755,7 @@ class TestLoadingOpp(unittest.TestCase):
                 obs = env.reset()
                 assert env._oppSpace.budget == init_budget
                 # The opponent can attack
-                for i in range(env._oppSpace.attack_duration):
+                for i in range(env._oppSpace.attack_max_duration):
                     obs, reward, done, info = env.step(env.action_space())
                     attack = env._oppSpace.last_attack
                     assert env._oppSpace.budget == init_budget - i - 1
@@ -1013,7 +1013,7 @@ class TestLoadingOpp(unittest.TestCase):
                     
                 attack = env._oppSpace.last_attack
                 attacked_line = np.where(attack._set_line_status == -1)[0][0]
-                if env._oppSpace.current_attack_duration < env._oppSpace.attack_duration:
+                if env._oppSpace.current_attack_duration < env._oppSpace.attack_max_duration:
                     # The attack is ungoing. The line must have been disconnected already
                     assert not pre_obs.line_status[attacked_line]
                 else:

--- a/grid2op/tests/test_Reward.py
+++ b/grid2op/tests/test_Reward.py
@@ -192,18 +192,51 @@ class TestIncreaseFlatReward(unittest.TestCase):
             warnings.filterwarnings("ignore")
             env = make("l2rpn_case14_sandbox", reward_class=IncreasingFlatReward, test=True)
 
-        assert env._current_time_step == 0
+        assert env.nb_time_step == 0
         obs, reward, done, info = env.step(env.action_space())
-        assert env._current_time_step == 1
+        assert env.nb_time_step == 1
         assert reward == 1
         obs, reward, done, info = env.step(env.action_space())
-        assert env._current_time_step == 2
+        assert env.nb_time_step == 2
         assert reward == 2
         obs = env.reset()
-        assert env._current_time_step == 0
+        assert env.nb_time_step == 0
         obs, reward, done, info = env.step(env.action_space())
-        assert env._current_time_step == 1
+        assert env.nb_time_step == 1
         assert reward == 1
+
+
+class TestEpisodeDurationReward(unittest.TestCase):
+    def test_ok(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = make("l2rpn_case14_sandbox", reward_class=EpisodeDurationReward, test=True)
+
+        assert env.nb_time_step == 0
+        obs, reward, done, info = env.step(env.action_space())
+        assert env.nb_time_step == 1
+        assert reward == 0
+
+        obs, reward, done, info = env.step(env.action_space())
+        assert env.nb_time_step == 2
+        assert reward == 0
+
+        obs, reward, done, info = env.step(env.action_space({"set_bus": {"generators_id": [(0, -1)]}}))
+        assert done
+        assert env.nb_time_step == 3
+        assert reward == 3. / 575.
+
+        obs = env.reset()
+        assert env.nb_time_step == 0
+        obs, reward, done, info = env.step(env.action_space())
+        assert env.nb_time_step == 1
+        assert reward == 0
+
+        env.fast_forward_chronics(573)
+        obs, reward, done, info = env.step(env.action_space())
+        assert done
+        assert env.nb_time_step == 575
+        assert reward == 1.
 
 
 if __name__ == "__main__":

--- a/grid2op/tests/test_Reward.py
+++ b/grid2op/tests/test_Reward.py
@@ -186,5 +186,25 @@ class TestCombinedReward(TestLoadingReward, unittest.TestCase):
         assert reward == 42.0
 
 
+class TestIncreaseFlatReward(unittest.TestCase):
+    def test_ok(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = make("l2rpn_case14_sandbox", reward_class=IncreasingFlatReward, test=True)
+
+        assert env._current_time_step == 0
+        obs, reward, done, info = env.step(env.action_space())
+        assert env._current_time_step == 1
+        assert reward == 1
+        obs, reward, done, info = env.step(env.action_space())
+        assert env._current_time_step == 2
+        assert reward == 2
+        obs = env.reset()
+        assert env._current_time_step == 0
+        obs, reward, done, info = env.step(env.action_space())
+        assert env._current_time_step == 1
+        assert reward == 1
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/grid2op/tests/test_Runner.py
+++ b/grid2op/tests/test_Runner.py
@@ -279,7 +279,7 @@ class TestRunner(HelperTests):
 
     def test_backward_compatibility(self):
         backward_comp_version = ["1.0.0", "1.1.0", "1.1.1", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.3.0", "1.3.1",
-                                 "1.4.0", "1.5.0"]
+                                 "1.4.0", "1.5.0", "1.5.1", "1.5.1.post1"]
         curr_version = "test_version"
         assert 'curtailment' in CompleteObservation.attr_list_vect, "error at the beginning"
         with warnings.catch_warnings():

--- a/grid2op/tests/test_gym_compat.py
+++ b/grid2op/tests/test_gym_compat.py
@@ -409,7 +409,7 @@ class TestGymCompatModule(unittest.TestCase):
         low = np.zeros(env.n_line, dtype=dt_int)
         high = np.zeros(env.n_line, dtype=dt_int) + max(env.parameters.NB_TIMESTEP_RECONNECTION,
                                                         env.parameters.NB_TIMESTEP_COOLDOWN_LINE,
-                                                        env._oppSpace.attack_duration)
+                                                        env._oppSpace.attack_max_duration)
         assert np.array_equal(env_gym.observation_space[key].low, low), f"issue for {key}"
         assert np.array_equal(env_gym.observation_space[key].high, high), f"issue for {key}"
 


### PR DESCRIPTION
- [BREAKING]: allow the opponent to chose the duration of its attack. This breaks the previous "Opponent.attack(...)"
  signature by adding an object in the return value. All code provided with grid2op are compatible with this
  new change. (for previously coded opponent, the only thing you have to do to make it compliant with
  the new interface is, in the `opponent.attack(...)` function return `whatever_you_returned_before, None` instead
  of simply `whatever_you_returned_before`
- [FIXED]: an issue with the `IncreasingFlatReward` reward types
- [ADDED]: a reward `EpisodeDurationReward` that is always 0 unless at the end of an episode where it returns a float
  proportional to the number of step made from the beginning of the environment.
- [ADDED]: in the `Observation` the possibility to retrieve the current number of steps