### PR TITLE
Merging in preparation of version 1.6.1, that will be used for icaps 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,6 +322,7 @@ OpponentCalibration.ipynb
 grid2op/data_test/l2rpn_neurips_2020_track1_with_alert/_statistics_do_nothing/
 save/
 shorten_env.py
+test_hash_env.py
 
 # profiling files
 **.prof

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ Change Log
 - [???] "asynch" multienv
 - [???] properly model interconnecting powerlines
 
+[1.6.1] - 2021-07-xx
+---------------------
+- [IMPROVED] now grid2op is able to check if an environment needs to be updated when calling `grid2op.update_env()`
+  thanks to the use of registered hash values.
+
 [1.6.0] (hotfix) - 2021-06-23
 ------------------------------
 - [FIXED] issue `Issue#235 <https://github.com/rte-france/Grid2Op/issues/235>`_ issue when using the "simulate"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,8 +25,12 @@ Change Log
 
 [1.6.1] - 2021-07-xx
 ---------------------
+- [FIXED] a bug in the "env.get_path_env()" in case `env` was a multimix (it returned the path of the current mix
+  instead of the path of the multimix environment)
 - [IMPROVED] now grid2op is able to check if an environment needs to be updated when calling `grid2op.update_env()`
   thanks to the use of registered hash values.
+- [IMPROVED] now grid2op will check if an update is available when an environment is being downloaded for the
+  first time.
 
 [1.6.0] (hotfix) - 2021-06-23
 ------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ Change Log
 ---------------------
 - [FIXED] a bug in the "env.get_path_env()" in case `env` was a multimix (it returned the path of the current mix
   instead of the path of the multimix environment)
+- [FIXED] a bug in the `backend.get_action_to_set()` and `backend.update_from_obs()` in case of disconnected shunt
+  with backend that supported shunts (values for `p` and `q` were set even if the shunt was disconnected, which
+  could lead to undefined behaviour)
 - [IMPROVED] now grid2op is able to check if an environment needs to be updated when calling `grid2op.update_env()`
   thanks to the use of registered hash values.
 - [IMPROVED] now grid2op will check if an update is available when an environment is being downloaded for the

--- a/grid2op/Download/DownloadDataset.py
+++ b/grid2op/Download/DownloadDataset.py
@@ -116,6 +116,10 @@ def _aux_download(url, dataset_name, path_data, ds_name_dl=None):
     # bug in the AWS file... named ".tar.tar.bz2" ...
     os.remove(output_path)
 
+    # check for update (if any)
+    from grid2op.MakeEnv.UpdateEnv import _update_files
+    _update_files(dataset_name)
+
     print("You may now use the environment \"{}\" with the available data by invoking:\n"
           "\tenv = grid2op.make(\"{}\")"
           "".format(dataset_name, dataset_name))

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -1763,6 +1763,19 @@ class BaseEnv(GridObjects, RandomObject, ABC):
                 self._sum_curtailment_mw = -self._sum_curtailment_mw_prev
                 self._sum_curtailment_mw_prev = dt_float(0.)
 
+            # case where the action modifies load (TODO maybe make a different env for that...)
+            for inj_key in ["load_p", "prod_p", "load_q"]:
+                # modification of the injections in the action, this erases the actions in the environment
+                if inj_key in action._dict_inj:
+                    if inj_key in self._env_modification._dict_inj:
+                            this_p_load = 1. * self._env_modification._dict_inj[inj_key]
+                            act_modif = action._dict_inj[inj_key]
+                            this_p_load[np.isfinite(act_modif)] = act_modif[np.isfinite(act_modif)]
+                            self._env_modification._dict_inj[inj_key][:] = this_p_load
+                    else:
+                            self._env_modification._dict_inj[inj_key] = 1.0 * action._dict_inj[inj_key]
+                            self._env_modification._modif_inj = True
+
             if self.n_storage > 0:
                 # TODO limit here if the ramps are too low !
                 # TODO in the above case, action should not be implemented !

--- a/grid2op/Environment/MultiMixEnv.py
+++ b/grid2op/Environment/MultiMixEnv.py
@@ -161,6 +161,7 @@ class MultiMixEnvironment(GridObjects, RandomObject):
         self.current_env = None
         self.env_index = None
         self.mix_envs = []
+        self._env_dir = os.path.abspath(envs_dir)
 
         # Special case handling for backend
         # TODO: with backend.copy() instead !
@@ -210,6 +211,16 @@ class MultiMixEnvironment(GridObjects, RandomObject):
         self.current_env.env_name = multi_env_name
         self.__class__ = self.init_grid(self.current_env)
         self.current_env.env_name = save_env_name
+
+    def get_path_env(self):
+        """
+        Get the path that allows to create this environment.
+
+        It can be used for example in `grid2op.utils.underlying_statistics` to save the information directly inside
+        the environment data.
+
+        """
+        return self._env_dir
 
     @property
     def current_index(self):

--- a/grid2op/MakeEnv/Make.py
+++ b/grid2op/MakeEnv/Make.py
@@ -48,10 +48,10 @@ TEST_DEV_ENVS = {
 _REQUEST_FAIL_EXHAUSTED_ERR = "Impossible to retrieve data at \"{}\".\n" \
                               "If the problem persists, please contact grid2op developers by sending an issue at " \
                               "https://github.com/rte-france/Grid2Op/issues"
-_REQUEST_FAIL_RETRY_ERR = "Failure to get a reponse from the url \"{}\".\n" \
-                          "Retrying.. {} attempt(s) remaining"
+_REQUEST_FAIL_RETRY_ERR = "Failure to get a response from the url \"{}\".\n" \
+                          "Retrying... {} attempt(s) remaining"
 _REQUEST_EXCEPT_RETRY_ERR = "Exception in getting an answer from \"{}\".\n" \
-                            "Retrying.. {} attempt(s) remaining"
+                            "Retrying... {} attempt(s) remaining"
 
 _LIST_REMOTE_URL = "https://api.github.com/repos/bdonnot/grid2op-datasets/contents/datasets.json"
 _LIST_REMOTE_KEY = "download_url"
@@ -60,7 +60,8 @@ _LIST_REMOTE_INVALID_CONTENT_JSON_ERR = "Impossible to retrieve available datase
                                         "Parsing error:\n {}"
 _LIST_REMOTE_CORRUPTED_CONTENT_JSON_ERR = "Corrupted json retrieved from github api. " \
                                          "Please wait a few minutes and try again. " \
-                                         "If the error persist, contact grid2op organizers"
+                                         "If the error persist, contact grid2op devs by making an issue at " \
+                                         "\n\thttps://github.com/rte-france/Grid2Op/issues/new/choose"
 _LIST_REMOTE_INVALID_DATASETS_JSON_ERR = "Impossible to retrieve available datasets. " \
                                          "File could not be converted to json. " \
                                          "The error was \n\"{}\""
@@ -110,7 +111,7 @@ def _send_request_retry(url, nb_retry=10, gh_session=None):
         raise
     except KeyboardInterrupt:
         raise
-    except:
+    except Exception as exc_:
         warnings.warn(_REQUEST_EXCEPT_RETRY_ERR.format(url, nb_retry-1))
         time.sleep(1)
         return _send_request_retry(url, nb_retry=nb_retry-1, gh_session=gh_session)
@@ -123,7 +124,7 @@ def _retrieve_github_content(url, is_json=True):
     except Exception as e:
         raise Grid2OpException(_LIST_REMOTE_INVALID_CONTENT_JSON_ERR.format(e))
 
-    if not _LIST_REMOTE_KEY in answer_json:
+    if _LIST_REMOTE_KEY not in answer_json:
         raise Grid2OpException(_LIST_REMOTE_CORRUPTED_CONTENT_JSON_ERR)
     time.sleep(1)
     avail_datasets = _send_request_retry(answer_json[_LIST_REMOTE_KEY])
@@ -175,13 +176,13 @@ def _extract_ds_name(dataset_path):
 
     try:
         dataset_path = str(dataset_path)
-    except:
-        raise Grid2OpException(_EXTRACT_DS_NAME_CONVERT_ERR.format(dataset_path))
+    except Exception as exc_:
+        raise Grid2OpException(_EXTRACT_DS_NAME_CONVERT_ERR.format(dataset_path)) from exc_
 
     try:
         dataset_name = os.path.split(dataset_path)[-1]
-    except:
-        raise UnknownEnv(_EXTRACT_DS_NAME_RECO_ERR.format(dataset_path))
+    except Exception as exc_:
+        raise UnknownEnv(_EXTRACT_DS_NAME_RECO_ERR.format(dataset_path)) from exc_
     dataset_name = dataset_name.lower().rstrip().lstrip()
     dataset_name = os.path.splitext(dataset_name)[0]
     return dataset_name

--- a/grid2op/MakeEnv/UpdateEnv.py
+++ b/grid2op/MakeEnv/UpdateEnv.py
@@ -144,7 +144,7 @@ def _update_files(env_name=None,
 # TODO make that a method of the environment maybe ?
 def _hash_env(path_local_env,
               hash_=None,
-              blocksize=4096,  # TODO is this correct ?
+              blocksize=64,  # TODO is this correct ?
               ):
     import hashlib  # lazy import
     if hash_ is None:
@@ -168,10 +168,15 @@ def _hash_env(path_local_env,
                     "grid_layout.json",
                     "prods_charac.csv"]:  # list the file we want to hash (we don't hash everything
             full_path_file = os.path.join(path_local_env, fn_)
+            import re
             if os.path.exists(full_path_file):
-                with open(full_path_file, "rb") as f:
-                    for block in iter(lambda: f.read(blocksize), b""):
-                        hash_.update(block)
+                with open(full_path_file, "r", encoding="utf-8") as f:
+                    text_ = f.read()
+                    text_ = re.sub("\s|\n|\r", "", text_)  # this is done to ensure a compatibility between platform
+                    # sometime git replaces the "\r\n" in windows with "\n" on linux / macos and it messes
+                    # up the hash
+                    hash_.update(text_.encode("utf-8"))
+
         # now I hash the chronics
         # but as i don't want to read every chronics (for time purposes) i will only hash the names
         # of all the chronics

--- a/grid2op/Opponent/WeightedRandomOpponent.py
+++ b/grid2op/Opponent/WeightedRandomOpponent.py
@@ -164,6 +164,6 @@ class WeightedRandomOpponent(BaseOpponent):
         rho = observation.rho[self._lines_ids][status] / self._rho_normalization[status]
         rho_sum = rho.sum()
         if rho_sum <= 0.:
-            return None
+            return None, 0
         attack = self.space_prng.choice(available_attacks, p=rho / rho_sum)
         return attack, None

--- a/grid2op/Opponent/WeightedRandomOpponent.py
+++ b/grid2op/Opponent/WeightedRandomOpponent.py
@@ -93,6 +93,8 @@ class WeightedRandomOpponent(BaseOpponent):
 
         # Opponent's attack period
         self._attack_period = attack_period
+        if self._attack_period <= 0:
+            raise OpponentError("Opponent attack cooldown need to be > 0")
 
     def reset(self, initial_budget):
         self._next_attack_time = None
@@ -157,13 +159,15 @@ class WeightedRandomOpponent(BaseOpponent):
 
         # If all attackable lines are disconnected, do not attack
         status = observation.line_status[self._lines_ids]
-        if np.all(~status):
+        if not np.sum(status):
             return None, 0
 
         available_attacks = self._attacks[status]
         rho = observation.rho[self._lines_ids][status] / self._rho_normalization[status]
         rho_sum = rho.sum()
         if rho_sum <= 0.:
+            # this case can happen if a powerline has a flow of 0.0 but is connected, and it's the only one
+            # that can be attacked... Pretty rare hey !
             return None, 0
         attack = self.space_prng.choice(available_attacks, p=rho / rho_sum)
         return attack, None

--- a/grid2op/tests/test_MakeEnv.py
+++ b/grid2op/tests/test_MakeEnv.py
@@ -652,7 +652,7 @@ class TestHashEnv(unittest.TestCase):
             env = make("l2rpn_case14_sandbox", test=True)
         path_ = env.get_path_env()
         hash_this_env = _hash_env(path_)
-        assert hash_this_env.hexdigest() == "45a2be9f1d2b206bba48d1fee5ab2343d22e818a4a66d785b90832d10b3b5ca1856dc99338fc543002cf3bfc701779ec85b9e864dca77f74e82f40d157442cd1", \
+        assert hash_this_env.hexdigest() == "35791e669b84c5da16061ab6aaf3f4748d32871a16fd97ebfc7acbf83104dbc00bc7878481fe35e14236f14eb86610700734f756295675dd5d8d0d918cec3770", \
                f"wrong hash digest. It's \n\t{hash_this_env.hexdigest()}"
 
 

--- a/grid2op/tests/test_MakeEnv.py
+++ b/grid2op/tests/test_MakeEnv.py
@@ -643,5 +643,17 @@ class TestMakeMultiMix(unittest.TestCase):
         assert isinstance(env, MultiMixEnvironment)
 
 
+class TestHashEnv(unittest.TestCase):
+    def test_hash(self):
+        from grid2op.MakeEnv.UpdateEnv import _hash_env
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = make("l2rpn_case14_sandbox", test=True)
+        path_ = env.get_path_env()
+        hash_this_env = _hash_env(path_)
+        assert hash_this_env.hexdigest() == "45a2be9f1d2b206bba48d1fee5ab2343d22e818a4a66d785b90832d10b3b5ca1856dc99338fc543002cf3bfc701779ec85b9e864dca77f74e82f40d157442cd1"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/grid2op/tests/test_MakeEnv.py
+++ b/grid2op/tests/test_MakeEnv.py
@@ -652,7 +652,8 @@ class TestHashEnv(unittest.TestCase):
             env = make("l2rpn_case14_sandbox", test=True)
         path_ = env.get_path_env()
         hash_this_env = _hash_env(path_)
-        assert hash_this_env.hexdigest() == "45a2be9f1d2b206bba48d1fee5ab2343d22e818a4a66d785b90832d10b3b5ca1856dc99338fc543002cf3bfc701779ec85b9e864dca77f74e82f40d157442cd1"
+        assert hash_this_env.hexdigest() == "45a2be9f1d2b206bba48d1fee5ab2343d22e818a4a66d785b90832d10b3b5ca1856dc99338fc543002cf3bfc701779ec85b9e864dca77f74e82f40d157442cd1", \
+               f"wrong hash digest. It's \n\t{hash_this_env.hexdigest()}"
 
 
 if __name__ == "__main__":

--- a/grid2op/tests/test_MultiMix.py
+++ b/grid2op/tests/test_MultiMix.py
@@ -29,6 +29,14 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert mme.current_obs is not None
         assert mme.current_env is not None
 
+    def test_get_path_env(self):
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        path_mme = mme.get_path_env()
+        for mix in mme:
+            path_mix = mix.get_path_env()
+            assert path_mme != path_mix
+            assert os.path.split(path_mix)[0] == path_mme
+
     def test_create_fail(self):
         with self.assertRaises(EnvError):
             mme = MultiMixEnvironment("/tmp/error")

--- a/grid2op/tests/test_issue_238.py
+++ b/grid2op/tests/test_issue_238.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import warnings
+
+import grid2op
+from grid2op.Chronics import ChangeNothing
+from grid2op.tests.helper_path_test import *
+from grid2op.Action import PowerlineSetAction
+from grid2op.Opponent import WeightedRandomOpponent, BaseActionBudget
+
+
+class Issue224Tester(unittest.TestCase):
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env_nm = "l2rpn_case14_sandbox"
+            lines_attacked = ["6_7_18"]
+            rho_normalization = [1.0]
+            opponent_attack_cooldown = 2  # need to be at least 1
+            opponent_attack_duration = 12
+            opponent_budget_per_ts = 9999.
+            opponent_init_budget = 9999.
+            self.env = grid2op.make(env_nm,
+                                    test=True,
+                                    # chronics_class=ChangeNothing,
+                                    opponent_attack_cooldown=opponent_attack_cooldown,
+                                    opponent_attack_duration=opponent_attack_duration,
+                                    opponent_budget_per_ts=opponent_budget_per_ts,
+                                    opponent_init_budget=opponent_init_budget,
+                                    opponent_action_class=PowerlineSetAction,
+                                    opponent_class=WeightedRandomOpponent,
+                                    opponent_budget_class=BaseActionBudget,
+                                    kwargs_opponent={"lines_attacked": lines_attacked,
+                                                     "rho_normalization": rho_normalization,
+                                                     "attack_period": opponent_attack_cooldown}
+                                    )
+            self.env.seed(0)
+            self.env.reset()
+
+    def test_opponent(self):
+        obs = self.env.reset()
+        assert obs.line_status[18], "line 18 should be connected"
+        # TODO this test does not really test it...
+        # TODO but i would need an env with a connected powerline with exactly 0 flow on it !
+        # assert obs.rho[18] == 0., "line 18 should not have any flow"
+
+        res = self.env._opponent.attack(obs, self.env.action_space(), self.env.action_space(), 100, False)
+        assert len(res) == 2, "it should return something of length 2"

--- a/grid2op/tests/test_utils.py
+++ b/grid2op/tests/test_utils.py
@@ -108,21 +108,16 @@ class TestL2RPNSCORE(HelperTests):
             assert os.path.exists(os.path.join(env.get_path_env(),
                                                EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
             assert os.path.exists(os.path.join(env.get_path_env(),
-                                               EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
+                                               EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                       EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
     def test_donothing_0(self):
         """test that do nothing has a score of 0.00"""
@@ -135,25 +130,20 @@ class TestL2RPNSCORE(HelperTests):
                 assert os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
                 assert os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
                 my_agent = DoNothingAgent(env.action_space)
                 my_scores, *_ = scores.get(my_agent)
                 assert np.max(np.abs(my_scores)) <= self.tol_one
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                        EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
     def test_modif_max_step_decrease(self):
         """
@@ -169,7 +159,7 @@ class TestL2RPNSCORE(HelperTests):
                 assert os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
                 assert os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
                 my_agent = DoNothingAgent(env.action_space)
                 my_scores, *_ = scores.get(my_agent)
@@ -177,24 +167,19 @@ class TestL2RPNSCORE(HelperTests):
 
                 scores2 = ScoreL2RPN2020(env, nb_scenario=2, verbose=0, max_step=10)
                 assert not scores2._recomputed_dn
-                assert not scores2._recomputed_no_ov
+                assert not scores2._recomputed_no_ov_rp
                 my_agent = DoNothingAgent(env.action_space)
                 my_scores2, *_ = scores2.get(my_agent)
                 assert np.max(np.abs(my_scores2)) <= self.tol_one, "error for the second do nothing"
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                        EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
     def test_modif_max_step_increase(self):
         """test that i can modify the max step (and that if I increase it it does trigger a recomputation)"""
@@ -207,7 +192,7 @@ class TestL2RPNSCORE(HelperTests):
                 assert os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
                 assert os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
                 my_agent = DoNothingAgent(env.action_space)
                 my_scores, *_ = scores.get(my_agent)
@@ -215,21 +200,16 @@ class TestL2RPNSCORE(HelperTests):
 
                 scores2 = ScoreL2RPN2020(env, nb_scenario=2, verbose=0, max_step=10)
                 assert scores2._recomputed_dn
-                assert scores2._recomputed_no_ov
+                assert scores2._recomputed_no_ov_rp
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                        EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
     def test_modif_nb_scenario(self):
         """
@@ -245,7 +225,7 @@ class TestL2RPNSCORE(HelperTests):
                 assert os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
                 assert os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
                 my_agent = DoNothingAgent(env.action_space)
                 my_scores, *_ = scores.get(my_agent)
@@ -253,25 +233,21 @@ class TestL2RPNSCORE(HelperTests):
 
                 scores2 = ScoreL2RPN2020(env, nb_scenario=4, verbose=0, max_step=5)
                 assert scores2._recomputed_dn
-                assert scores2._recomputed_no_ov
+                assert scores2._recomputed_no_ov_rp
 
                 scores2 = ScoreL2RPN2020(env, nb_scenario=3, verbose=0, max_step=5)
                 assert not scores2._recomputed_dn
-                assert not scores2._recomputed_no_ov
+                assert not scores2._recomputed_no_ov_rp
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            # delete them
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                        EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
     def test_reco_noov_80(self):
         """test that do nothing has a score of 80.0 if it is run with "no overflow disconnection" """
@@ -281,14 +257,13 @@ class TestL2RPNSCORE(HelperTests):
                 # I cannot decrease the max step: it must be above the number of steps the do nothing does
                 scores = ScoreL2RPN2020(env, nb_scenario=2, verbose=0, max_step=130)
                 assert scores._recomputed_dn
-                assert scores._recomputed_no_ov
                 assert scores._recomputed_no_ov_rp
 
                 # the statistics have been properly computed
                 assert os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
                 assert os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
                 my_agent = DoNothingAgent(env.action_space)
                 my_scores, *_ = scores.get(my_agent)
@@ -299,25 +274,20 @@ class TestL2RPNSCORE(HelperTests):
             with make("rte_case5_example", test=True, param=param) as env:
                 scores2 = ScoreL2RPN2020(env, nb_scenario=2, verbose=0, max_step=130)
                 assert not scores2._recomputed_dn
-                assert not scores2._recomputed_no_ov
                 assert not scores2._recomputed_no_ov_rp
                 my_agent = RecoPowerlineAgent(env.action_space)
                 my_scores, *_ = scores2.get(my_agent)
                 assert np.max(np.abs(np.array(my_scores) - 80.0)) <= self.tol_one
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            # delete them
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
                                                    EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                        EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
 
 class TestICAPSSCORE(HelperTests):
@@ -334,8 +304,8 @@ class TestICAPSSCORE(HelperTests):
                                         env_seeds=[1, 2],  # with these seeds do nothing goes till the end
                                         agent_seeds=[3, 4])
                 my_agent = DoNothingAgent(env.action_space)
-                scores, n_played, total_ts = scores.get(my_agent)
-                for (ep_score, op_score, alarm_score) in scores:
+                scores_this, n_played, total_ts = scores.get(my_agent)
+                for (ep_score, op_score, alarm_score) in scores_this:
                     assert np.abs(ep_score - 30.) <= self.tol_one, f"wrong score for the episode: {ep_score} vs 30."
                     assert np.abs(op_score - 0.) <= self.tol_one, f"wrong score for the operationnal cost: " \
                                                                   f"{op_score} vs 0."
@@ -346,21 +316,16 @@ class TestICAPSSCORE(HelperTests):
             assert os.path.exists(os.path.join(env.get_path_env(),
                                                EpisodeStatistics.get_name_dir(ScoreICAPS2021.NAME_DN)))
             assert os.path.exists(os.path.join(env.get_path_env(),
-                                               EpisodeStatistics.get_name_dir(ScoreICAPS2021.NAME_DN_NO_OVERWLOW)))
+                                               EpisodeStatistics.get_name_dir(ScoreICAPS2021.NAME_RP_NO_OVERFLOW)))
 
             # delete them
-            stats_0 = EpisodeStatistics(env, ScoreICAPS2021.NAME_DN)
-            stats_1 = EpisodeStatistics(env, ScoreICAPS2021.NAME_DN_NO_OVERWLOW)
-            stats_2 = EpisodeStatistics(env, ScoreICAPS2021.NAME_RP_NO_OVERWLOW)
-            stats_0.clear_all()
-            stats_1.clear_all()
-            stats_2.clear_all()
+            scores.clear_all()
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreICAPS2021.NAME_DN)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN)))
+            # assert not os.path.exists(os.path.join(env.get_path_env(),
+            #                                        EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_DN_NO_OVERWLOW)))
             assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreICAPS2021.NAME_DN_NO_OVERWLOW)))
-            assert not os.path.exists(os.path.join(env.get_path_env(),
-                                                   EpisodeStatistics.get_name_dir(ScoreICAPS2021.NAME_RP_NO_OVERWLOW)))
+                                                   EpisodeStatistics.get_name_dir(ScoreL2RPN2020.NAME_RP_NO_OVERFLOW)))
 
 
 if __name__ == "__main__":

--- a/grid2op/utils/icaps_2021_scores.py
+++ b/grid2op/utils/icaps_2021_scores.py
@@ -79,7 +79,7 @@ class ScoreICAPS2021(ScoreL2RPN2020):
     """
 
     NAME_DN = "icaps2021_dn"
-    NAME_DN_NO_OVERWLOW = "icaps2021_no_overflow"
+    # NAME_DN_NO_OVERFLOW = "icaps2021_no_overflow"
     NAME_RP_NO_OVERWLOW = "icaps2021_no_overflow_reco"
 
     def __init__(self,


### PR DESCRIPTION
- [FIXED] a bug in the "env.get_path_env()" in case `env` was a multimix (it returned the path of the current mix
  instead of the path of the multimix environment)
- [FIXED] a bug in the `backend.get_action_to_set()` and `backend.update_from_obs()` in case of disconnected shunt
  with backend that supported shunts (values for `p` and `q` were set even if the shunt was disconnected, which
  could lead to undefined behaviour)
- [IMPROVED] now grid2op is able to check if an environment needs to be updated when calling `grid2op.update_env()`
  thanks to the use of registered hash values.
- [IMPROVED] now grid2op will check if an update is available when an environment is being downloaded for the
  first time.