### PR TITLE
Time out env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,6 +370,7 @@ test_vecenv.py
 test_timeout_env.py
 test_pp_networks.py
 test_timeout_env.py
+test_timeout_env.py
 
 # profiling files
 **.prof

--- a/.gitignore
+++ b/.gitignore
@@ -368,6 +368,8 @@ test_multi_step_for.py
 test_vecenv.7z
 test_vecenv.py
 test_timeout_env.py
+test_pp_networks.py
+test_timeout_env.py
 
 # profiling files
 **.prof

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -118,7 +118,9 @@ Change Log
   env backend and the obs backend.
 - [IMPROVED] the environment now called the "chronics_handler.forecast" function at most once per step.
 - [IMPROVED] make it easier to create an environment without `MultiFolder` or `MultifolderWithCache`
-
+- [IMPROVED] add the possibility to forward kwargs to chronix2grid function when calling `env.generate_data`
+- [IMPROVED] when calling `env.generate_data` an extra file (json) will be read to set default values 
+  passed to `chronix2grid.add_data`
 
 [1.8.1] - 2023-01-11
 ---------------------

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -2967,7 +2967,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
 
         except StopIteration:
             # episode is over
-            print("I got a StopIteration")
             is_done = True
             
         self._backend_action.reset()

--- a/grid2op/Environment/Environment.py
+++ b/grid2op/Environment/Environment.py
@@ -1714,7 +1714,7 @@ class Environment(BaseEnv):
         res["_is_test"] = self._is_test  # TODO not implemented !!
         return res
 
-    def generate_data(self, nb_year=1, nb_core=1, seed=None):
+    def generate_data(self, nb_year=1, nb_core=1, seed=None, **kwargs):
         """This function uses the chronix2grid package to generate more data that will then
         be available locally. You need to install it independently (see https://github.com/BDonnot/ChroniX2Grid#installation
         for more information)
@@ -1762,6 +1762,8 @@ class Environment(BaseEnv):
             number of computer cores to use, by default 1.
         seed: int, optional
             If the same seed is given, then the same data will be generated.
+        **kwargs:
+            key word arguments passed to `add_data` function of `chronix2grid.grid2op_utils` module
         """
         try:
             from chronix2grid.grid2op_utils import add_data
@@ -1771,6 +1773,18 @@ class Environment(BaseEnv):
                 f"Please visit https://github.com/bdonnot/chronix2grid#installation "
                 f"for further install instructions."
             ) from exc_
+        pot_file = None
+        if self.get_path_env() is not None:
+            pot_file = os.path.join(self.get_path_env(), "chronix2grid_adddata_kwargs.json")
+        if os.path.exists(pot_file) and os.path.isfile(pot_file):
+            import json
+            with open(pot_file, "r", encoding="utf-8") as f:
+                kwargs_default = json.load(f)
+            for el in kwargs_default:
+                if not el in kwargs:
+                    kwargs[el] = kwargs_default[el]
+        # TODO logger here for the kwargs used (including seed=seed, nb_scenario=nb_year, nb_core=nb_core)
         add_data(
-            env=self, seed=seed, nb_scenario=nb_year, nb_core=nb_core, with_loss=True
+            env=self, seed=seed, nb_scenario=nb_year, nb_core=nb_core,
+            **kwargs
         )

--- a/grid2op/tests/test_fromChronix2grid.py
+++ b/grid2op/tests/test_fromChronix2grid.py
@@ -52,21 +52,23 @@ class TestFromChronix2Grid(unittest.TestCase):
         id_ref = '377638611@2050-02-28'
         # test tell_id
         sum_prod_ref = 42340.949878
+        sum_prod_ref = 41784.477161
         self.env.seed(self.seed_)
         self.env.reset()
         id_ = self.env.chronics_handler.get_id()
         assert id_ == id_ref, f"wrong id {id_} instead of {id_ref}"
-        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - sum_prod_ref) <= 1e-4
+        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - sum_prod_ref) <= 1e-4, f"{self.env.chronics_handler.real_data._gen_p.sum():.2f}"
         self.env.reset()
-        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - 38160.833356999996) <= 1e-4
+        # assert abs(self.env.chronics_handler.real_data._gen_p.sum() - 38160.833356999996) <= 1e-4
+        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - 37662.206248999995) <= 1e-4, f"{self.env.chronics_handler.real_data._gen_p.sum():.2f}"
         self.env.set_id(id_ref)
         self.env.reset()
-        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - sum_prod_ref) <= 1e-4
+        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - sum_prod_ref) <= 1e-4, f"{self.env.chronics_handler.real_data._gen_p.sum():.2f}"
         
         # test seed
         self.env.seed(self.seed_)
         self.env.reset()
-        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - sum_prod_ref) <= 1e-4
+        assert abs(self.env.chronics_handler.real_data._gen_p.sum() - sum_prod_ref) <= 1e-4, f"{self.env.chronics_handler.real_data._gen_p.sum():.2f}"
         
     def test_episode(self):
         """test that the episode can go until the end"""

--- a/grid2op/tests/test_timeOutEnvironment.py
+++ b/grid2op/tests/test_timeOutEnvironment.py
@@ -14,11 +14,12 @@ import grid2op
 from grid2op.Environment import TimedOutEnvironment
 from grid2op.Agent import BaseAgent
 
+# Nota : time.sleep vs time.perf_counter() seems precise up to approx. 30 ms.
 
 class AgentOK(BaseAgent):
     def __init__(self, env):
         super().__init__(env.action_space)
-        self.time_out_ms = 0.8 * env.time_out_ms
+        self.time_out_ms = 0.7 * env.time_out_ms
         
     def act(self, obs, reward, done):
         time.sleep(1e-3 * self.time_out_ms)
@@ -28,7 +29,7 @@ class AgentOK(BaseAgent):
 class AgentKO(BaseAgent):
     def __init__(self, env):
         super().__init__(env.action_space)
-        self.time_out_ms = 1 * env.time_out_ms
+        self.time_out_ms = 1.3 * env.time_out_ms
         
     def act(self, obs, reward, done):
         time.sleep(1e-3 * self.time_out_ms)
@@ -38,7 +39,7 @@ class AgentKO(BaseAgent):
 class AgentKO1(BaseAgent):
     def __init__(self, env):
         super().__init__(env.action_space)
-        self.time_out_ms = 1.8 * env.time_out_ms
+        self.time_out_ms = 1.7 * env.time_out_ms
         
     def act(self, obs, reward, done):
         time.sleep(1e-3 * self.time_out_ms)
@@ -48,7 +49,7 @@ class AgentKO1(BaseAgent):
 class AgentKO2(BaseAgent):
     def __init__(self, env):
         super().__init__(env.action_space)
-        self.time_out_ms = 2.0 * env.time_out_ms
+        self.time_out_ms = 2.3 * env.time_out_ms
         
     def act(self, obs, reward, done):
         time.sleep(1e-3 * self.time_out_ms)
@@ -63,7 +64,7 @@ class TestTimedOutEnvironment100(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             # TODO : Comment on fait avec un time out ?
-            self.env1 = TimedOutEnvironment(grid2op.make("l2rpn_case14_sandbox"),
+            self.env1 = TimedOutEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True),
                                             time_out_ms=self.get_timeout_ms())
         params = self.env1.parameters
         params.NO_OVERFLOW_DISCONNECTION = True

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ pkgs["extras"]["test"] += pkgs["extras"]["chronix2grid"]
 if sys.version_info.minor <= 7:
     # typing "Literal" not available on python 3.7
     pkgs["required"].append("typing_extensions")
-    pkgs["required"][3] = "pandapower>=2.2.2<2.12"
+    pkgs["required"][3] = "pandapower>=2.2.2,<2.12"
 
 setup(description='An gym compatible environment to model sequential decision making  for powersystems',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,8 @@ pkgs["extras"]["test"] += pkgs["extras"]["plot"]
 pkgs["extras"]["test"] += pkgs["extras"]["chronix2grid"]
 if sys.version_info.minor <= 7:
     # typing "Literal" not available on python 3.7
-    pkgs["required"] = "typing_extensions"
+    pkgs["required"].append("typing_extensions")
+    pkgs["required"][3] = "pandapower>=2.2.2<2.12"
 
 setup(description='An gym compatible environment to model sequential decision making  for powersystems',
       long_description=long_description,


### PR DESCRIPTION
Integration des tests du 17/4, non intégrés dans mon 1er pull request du 17...

Concernant la marge des tests, voila les temps mesurés pour l'agent "1,75*timeOut" (ci-dessous)
=> l'incertitude sur time.sleep() semble etre de +/- 12 ms (sur mon PC), ce qui dépasse les 20% pour le test avec un timeOut à 50 ms
=> Je préconise de garder 30%, ou au moins 20 ms

Code reproductible
modif de test_TimeOutEnvironment.py, ligne 100 à 103 : 
            debut = time.perf_counter()
            act = agentko.act(None, None, None)
            fin   = time.perf_counter()
            print(f"durée agentKO1: {fin - debut}")



Test à 50 ms, avec un agentKO1 qui dort 1,75*timeOut : 
...F.durée agentKO1: 0.09078309999999945
durée agentKO1: 0.09359969999999862
durée agentKO1: 0.09265159999999995
durée agentKO1: 0.09135240000000167
durée agentKO1: 0.08922719999999984
durée agentKO1: 0.0901662000000023
durée agentKO1: 0.09010899999999822
durée agentKO1: 0.08414499999999947
durée agentKO1: 0.09942789999999846
durée agentKO1: 0.09039630000000187
=> L'incertitude atteint 12 ms, ce qui fait planter le test.
